### PR TITLE
feat: add technical indicators to main stock chart

### DIFF
--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -223,8 +223,7 @@ export function Chart() {
 
   const srLevels = useMemo(() => {
     if (!indicatorData || !indicators.sr || !activeChartData.length) return [];
-    const referencePrice = activeChartData[activeChartData.length - 1]?.price;
-    if (referencePrice == null) return [];
+    const referencePrice = activeChartData[activeChartData.length - 1].price;
     const prices = activeChartData.map((d) => d.price);
     const minPrice = Math.min(...prices);
     const maxPrice = Math.max(...prices);

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -223,8 +223,8 @@ export function Chart() {
 
   const srLevels = useMemo(() => {
     if (!indicatorData || !indicators.sr || !activeChartData.length) return [];
-    const latestPrice = activeChartData[activeChartData.length - 1]?.price;
-    if (latestPrice == null) return [];
+    const referencePrice = activeChartData[activeChartData.length - 1]?.price;
+    if (referencePrice == null) return [];
     const prices = activeChartData.map((d) => d.price);
     const minPrice = Math.min(...prices);
     const maxPrice = Math.max(...prices);
@@ -237,7 +237,7 @@ export function Chart() {
       )
       .sort(
         (a, b) =>
-          Math.abs(a.level - latestPrice) - Math.abs(b.level - latestPrice),
+          Math.abs(a.level - referencePrice) - Math.abs(b.level - referencePrice),
       )
       .slice(0, 10);
   }, [indicatorData, indicators.sr, activeChartData]);

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -1,18 +1,31 @@
 "use client";
 
 import { LoaderCircle } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
+  Area,
+  Bar,
   CartesianGrid,
-  AreaChart,
+  Cell,
+  ComposedChart,
+  Line,
+  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis,
-  Area,
 } from "recharts";
 
 import { ChartTooltip } from "~/components/ui/chart";
+import { useIndicatorPreferences } from "~/hooks/use-indicator-preferences";
 import { useSymbol } from "~/hooks/use-symbol";
+import {
+  calculateBollingerBands,
+  calculateMACD,
+  calculateRSI,
+  calculateSupportResistance,
+  calculateVWAP,
+  type OHLCVData,
+} from "~/lib/indicators";
 import { api } from "~/trpc/react";
 
 const PriceChange = ({ data }: { data?: { price: number }[] }) => {
@@ -86,30 +99,33 @@ const CustomTooltip = ({
 
 type TimeFrame = "5Y" | "1Y" | "6M" | "1M" | "1W" | "1D";
 
-const filterDataByTimeFrame = (
-  data: {
-    date: string;
-    price: number;
-  }[],
+const VWAP_TIMEFRAMES: TimeFrame[] = ["1M", "1W", "1D"];
+
+interface ChartDataPoint extends OHLCVData {
+  price: number;
+}
+
+const filterDataByTimeFrame = <T extends { date: string }>(
+  data: T[],
   timeFrame: TimeFrame,
-) => {
+): T[] => {
   const sortedData = [...data].sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   );
 
   switch (timeFrame) {
     case "5Y":
-      return sortedData.slice(-252 * 5); // ~252 trading days per year
+      return sortedData.slice(-252 * 5);
     case "1Y":
       return sortedData.slice(-252);
     case "6M":
-      return sortedData.slice(-126); // ~21 trading days * 6
+      return sortedData.slice(-126);
     case "1M":
-      return sortedData.slice(-21); // ~21 trading days
+      return sortedData.slice(-21);
     case "1W":
-      return sortedData.slice(-5); // 5 trading days
+      return sortedData.slice(-5);
     case "1D":
-      return sortedData.slice(-1); // Latest day
+      return sortedData.slice(-1);
     default:
       return sortedData;
   }
@@ -118,6 +134,8 @@ const filterDataByTimeFrame = (
 export function Chart() {
   const [timeFrame, setTimeFrame] = useState<TimeFrame>("1Y");
   const [symbol] = useSymbol();
+  const [indicators, toggleIndicator] = useIndicatorPreferences();
+
   const { data, isLoading } = api.asset.equityPriceHistoricalFMP.useQuery(
     symbol ?? "",
     {
@@ -136,29 +154,118 @@ export function Chart() {
       enabled: timeFrame === "1D" && !!symbol,
     });
 
-  if (!symbol) {
-    return <NoSymbolMessage />;
-  }
+  const chartData: ChartDataPoint[] = useMemo(() => {
+    if (!data?.historical) return [];
+    return [...data.historical]
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      .map((r) => ({
+        date: r.date,
+        price: r.close,
+        open: r.open,
+        high: r.high,
+        low: r.low,
+        close: r.close,
+        volume: r.volume,
+      }));
+  }, [data]);
 
-  if (isLoading || isLoading2) {
-    return <ChartSkeleton />;
-  }
-
-  const chartData = data?.historical
-    ?.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-    .map((result) => ({
-      date: result.date,
-      price: result.close,
+  const chartData2: ChartDataPoint[] = useMemo(() => {
+    if (!data2?.results) return [];
+    return data2.results.map((r) => ({
+      date: r.date,
+      price: r.close,
+      open: r.open,
+      high: r.high,
+      low: r.low,
+      close: r.close,
+      volume: r.volume,
     }));
+  }, [data2]);
 
-  const chartData2 = data2?.results?.map((result) => ({
-    date: result.date,
-    price: result.close,
-  }));
+  const activeChartData: ChartDataPoint[] = useMemo(() => {
+    if (timeFrame === "1D") return chartData2;
+    return filterDataByTimeFrame(chartData, timeFrame);
+  }, [timeFrame, chartData, chartData2]);
 
-  const filteredData = chartData
-    ? filterDataByTimeFrame(chartData ?? [], timeFrame)
-    : [];
+  const indicatorData = useMemo(() => {
+    if (!activeChartData.length) return null;
+    return {
+      vwap: calculateVWAP(activeChartData),
+      bollinger: calculateBollingerBands(activeChartData),
+      rsi: calculateRSI(activeChartData),
+      macd: calculateMACD(activeChartData),
+      sr: calculateSupportResistance(activeChartData),
+    };
+  }, [activeChartData]);
+
+  const showVWAP = indicators.vwap && VWAP_TIMEFRAMES.includes(timeFrame);
+
+  const mergedData = useMemo(() => {
+    if (!indicatorData) return activeChartData;
+    return activeChartData.map((d, i) => ({
+      ...d,
+      ...(showVWAP ? { vwap: indicatorData.vwap[i]?.vwap } : {}),
+      ...(indicators.bollinger
+        ? {
+            bbUpper: indicatorData.bollinger[i]?.bbUpper,
+            bbMiddle: indicatorData.bollinger[i]?.bbMiddle,
+            bbLower: indicatorData.bollinger[i]?.bbLower,
+          }
+        : {}),
+      ...(indicators.rsi ? { rsi: indicatorData.rsi[i]?.rsi } : {}),
+      ...(indicators.macd
+        ? {
+            macdLine: indicatorData.macd[i]?.macdLine,
+            macdSignal: indicatorData.macd[i]?.macdSignal,
+            macdHistogram: indicatorData.macd[i]?.macdHistogram,
+          }
+        : {}),
+    }));
+  }, [activeChartData, indicatorData, showVWAP, indicators]);
+
+  const srLevels = useMemo(() => {
+    if (!indicatorData || !indicators.sr || !activeChartData.length) return [];
+    const prices = activeChartData.map((d) => d.price);
+    const minPrice = Math.min(...prices);
+    const maxPrice = Math.max(...prices);
+    const range = maxPrice - minPrice;
+    return indicatorData.sr
+      .filter(
+        (lvl) =>
+          lvl.level >= minPrice - range * 0.05 &&
+          lvl.level <= maxPrice + range * 0.05,
+      )
+      .slice(0, 10);
+  }, [indicatorData, indicators.sr, activeChartData]);
+
+  const showRSI = indicators.rsi;
+  const showMACD = indicators.macd;
+  const hasSubCharts = showRSI || showMACD;
+
+  if (!symbol) return <NoSymbolMessage />;
+  if (isLoading || isLoading2) return <ChartSkeleton />;
+
+  const indicatorButtons: { key: keyof typeof indicators; label: string }[] = [
+    { key: "vwap", label: "VWAP" },
+    { key: "bollinger", label: "Bollinger" },
+    { key: "rsi", label: "RSI" },
+    { key: "macd", label: "MACD" },
+    { key: "sr", label: "S/R" },
+  ];
+
+  const tickFormatter = (value: string) => {
+    const date = new Date(value);
+    if (timeFrame === "1D")
+      return date.toLocaleString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    return date.toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: date.getMonth() === 0 ? "numeric" : undefined,
+    });
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -184,60 +291,230 @@ export function Chart() {
             </button>
           ))}
         </div>
-        <PriceChange data={timeFrame === "1D" ? chartData2 : filteredData} />
+        <PriceChange
+          data={timeFrame === "1D" ? chartData2 : activeChartData}
+        />
       </div>
 
-      <ResponsiveContainer>
-        <AreaChart
-          accessibilityLayer
-          data={timeFrame === "1D" ? chartData2 : filteredData}
-        >
-          <defs>
-            <linearGradient id="colorPv" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
-              <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
-            </linearGradient>
-          </defs>
-
-          <CartesianGrid vertical={false} />
-          <XAxis
-            fontSize={12}
-            dataKey="date"
-            minTickGap={50}
-            interval="preserveStartEnd"
-            tickFormatter={(value: string) => {
-              const date = new Date(value);
-
-              if (timeFrame === "1D")
-                return date.toLocaleString("en-US", {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-
-              return date.toLocaleString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: date.getMonth() === 0 ? "numeric" : undefined,
-              });
+      <div className="flex gap-2 px-2 pb-2">
+        {indicatorButtons.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleIndicator(key);
             }}
-          />
-          <YAxis
-            fontSize={12}
-            dataKey="price"
-            type="number"
-            domain={["dataMin", "dataMax"]}
-            tickFormatter={(value: number) => value?.toFixed(2)}
-          />
-          <ChartTooltip content={<CustomTooltip />} />
-          <Area
-            dataKey="price"
-            stroke="#82ca9d"
-            fillOpacity={1}
-            fill="url(#colorPv)"
-            dot={false}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+            className={`rounded px-3 py-1 text-xs ${
+              indicators[key]
+                ? "bg-[#424975] text-white"
+                : "bg-transparent text-gray-500 hover:bg-[#424975]/50"
+            }`}
+            style={{ zIndex: 100 }}
+            onTouchStart={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            accessibilityLayer
+            data={mergedData}
+            margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+          >
+            <defs>
+              <linearGradient id="colorPv" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+
+            <CartesianGrid vertical={false} />
+            <XAxis
+              fontSize={12}
+              dataKey="date"
+              minTickGap={50}
+              interval="preserveStartEnd"
+              tickFormatter={tickFormatter}
+            />
+            <YAxis
+              fontSize={12}
+              type="number"
+              domain={["auto", "auto"]}
+              tickFormatter={(value: number) => value?.toFixed(2)}
+              width={65}
+            />
+            <ChartTooltip content={<CustomTooltip />} />
+
+            <Area
+              dataKey="price"
+              stroke="#82ca9d"
+              fillOpacity={1}
+              fill="url(#colorPv)"
+              dot={false}
+              isAnimationActive={false}
+            />
+
+            {showVWAP && (
+              <Line
+                dataKey="vwap"
+                stroke="#3b82f6"
+                strokeWidth={1.5}
+                strokeDasharray="5 5"
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            )}
+
+            {indicators.bollinger && (
+              <>
+                <Line
+                  dataKey="bbUpper"
+                  stroke="#ef4444"
+                  strokeWidth={1}
+                  strokeOpacity={0.6}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls={false}
+                />
+                <Line
+                  dataKey="bbMiddle"
+                  stroke="#eab308"
+                  strokeWidth={1}
+                  strokeOpacity={0.6}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls={false}
+                />
+                <Line
+                  dataKey="bbLower"
+                  stroke="#22c55e"
+                  strokeWidth={1}
+                  strokeOpacity={0.6}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls={false}
+                />
+              </>
+            )}
+
+            {indicators.sr &&
+              srLevels.map((lvl, idx) => (
+                <ReferenceLine
+                  key={`${lvl.type}-${idx}`}
+                  y={lvl.level}
+                  stroke={lvl.type === "support" ? "#22c55e" : "#ef4444"}
+                  strokeDasharray="4 4"
+                  strokeOpacity={0.7}
+                  label={{
+                    value: lvl.type === "support" ? "S" : "R",
+                    position: "insideTopRight",
+                    fontSize: 10,
+                    fill: lvl.type === "support" ? "#22c55e" : "#ef4444",
+                  }}
+                />
+              ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {showRSI && (
+        <div style={{ height: 90 }}>
+          <div className="px-2 pt-1 text-xs text-gray-400">RSI (14)</div>
+          <ResponsiveContainer width="100%" height={72}>
+            <ComposedChart
+              data={mergedData}
+              margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+            >
+              <XAxis dataKey="date" hide />
+              <YAxis
+                domain={[0, 100]}
+                ticks={[30, 70]}
+                fontSize={10}
+                width={65}
+              />
+              <ReferenceLine
+                y={70}
+                stroke="#ef4444"
+                strokeDasharray="3 3"
+                strokeOpacity={0.5}
+              />
+              <ReferenceLine
+                y={30}
+                stroke="#22c55e"
+                strokeDasharray="3 3"
+                strokeOpacity={0.5}
+              />
+              <Line
+                dataKey="rsi"
+                stroke="#a855f7"
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {showMACD && (
+        <div style={{ height: 90 }}>
+          <div className="px-2 pt-1 text-xs text-gray-400">MACD (12,26,9)</div>
+          <ResponsiveContainer width="100%" height={72}>
+            <ComposedChart
+              data={mergedData}
+              margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+            >
+              <XAxis dataKey="date" hide />
+              <YAxis fontSize={10} width={65} />
+              <ReferenceLine y={0} stroke="#6b7280" strokeOpacity={0.4} />
+              <Bar
+                dataKey="macdHistogram"
+                isAnimationActive={false}
+                maxBarSize={4}
+              >
+                {mergedData.map((entry, idx) => {
+                  const val = (
+                    entry as unknown as Record<string, number | null | undefined>
+                  ).macdHistogram;
+                  return (
+                    <Cell
+                      key={`macd-cell-${idx}`}
+                      fill={
+                        val != null && val >= 0 ? "#22c55e" : "#ef4444"
+                      }
+                    />
+                  );
+                })}
+              </Bar>
+              <Line
+                dataKey="macdLine"
+                stroke="#3b82f6"
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+              <Line
+                dataKey="macdSignal"
+                stroke="#f97316"
+                strokeWidth={1.5}
+                strokeDasharray="3 3"
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {!hasSubCharts && <div />}
     </div>
   );
 }

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -109,25 +109,21 @@ const filterDataByTimeFrame = <T extends { date: string }>(
   data: T[],
   timeFrame: TimeFrame,
 ): T[] => {
-  const sortedData = [...data].sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-  );
-
   switch (timeFrame) {
     case "5Y":
-      return sortedData.slice(-252 * 5);
+      return data.slice(-252 * 5);
     case "1Y":
-      return sortedData.slice(-252);
+      return data.slice(-252);
     case "6M":
-      return sortedData.slice(-126);
+      return data.slice(-126);
     case "1M":
-      return sortedData.slice(-21);
+      return data.slice(-21);
     case "1W":
-      return sortedData.slice(-5);
+      return data.slice(-5);
     case "1D":
-      return sortedData.slice(-1);
+      return data.slice(-1);
     default:
-      return sortedData;
+      return data;
   }
 };
 
@@ -171,15 +167,17 @@ export function Chart() {
 
   const chartData2: ChartDataPoint[] = useMemo(() => {
     if (!data2?.results) return [];
-    return data2.results.map((r) => ({
-      date: r.date,
-      price: r.close,
-      open: r.open,
-      high: r.high,
-      low: r.low,
-      close: r.close,
-      volume: r.volume,
-    }));
+    return [...data2.results]
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      .map((r) => ({
+        date: r.date,
+        price: r.close,
+        open: r.open,
+        high: r.high,
+        low: r.low,
+        close: r.close,
+        volume: r.volume,
+      }));
   }, [data2]);
 
   const activeChartData: ChartDataPoint[] = useMemo(() => {
@@ -225,6 +223,8 @@ export function Chart() {
 
   const srLevels = useMemo(() => {
     if (!indicatorData || !indicators.sr || !activeChartData.length) return [];
+    const latestPrice = activeChartData[activeChartData.length - 1]?.price;
+    if (latestPrice == null) return [];
     const prices = activeChartData.map((d) => d.price);
     const minPrice = Math.min(...prices);
     const maxPrice = Math.max(...prices);
@@ -235,11 +235,23 @@ export function Chart() {
           lvl.level >= minPrice - range * 0.05 &&
           lvl.level <= maxPrice + range * 0.05,
       )
+      .sort(
+        (a, b) =>
+          Math.abs(a.level - latestPrice) - Math.abs(b.level - latestPrice),
+      )
       .slice(0, 10);
   }, [indicatorData, indicators.sr, activeChartData]);
 
-  const showRSI = indicators.rsi;
-  const showMACD = indicators.macd;
+  const showRSI =
+    indicators.rsi && !!indicatorData?.rsi.some((point) => point.rsi != null);
+  const showMACD =
+    indicators.macd &&
+    !!indicatorData?.macd.some(
+      (point) =>
+        point.macdLine != null ||
+        point.macdSignal != null ||
+        point.macdHistogram != null,
+    );
   const hasSubCharts = showRSI || showMACD;
 
   if (!symbol) return <NoSymbolMessage />;

--- a/src/hooks/use-indicator-preferences.ts
+++ b/src/hooks/use-indicator-preferences.ts
@@ -26,24 +26,30 @@ export function useIndicatorPreferences(): [
 ] {
   const [preferences, setPreferences] =
     useState<IndicatorPreferences>(DEFAULT_PREFERENCES);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       try {
-        setPreferences({ ...DEFAULT_PREFERENCES, ...(JSON.parse(stored) as Partial<IndicatorPreferences>) });
+        setPreferences({
+          ...DEFAULT_PREFERENCES,
+          ...(JSON.parse(stored) as Partial<IndicatorPreferences>),
+        });
       } catch {
         // ignore malformed stored data
       }
     }
+    setHasLoaded(true);
   }, []);
 
+  useEffect(() => {
+    if (!hasLoaded) return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  }, [hasLoaded, preferences]);
+
   const toggle = (key: keyof IndicatorPreferences) => {
-    setPreferences((prev) => {
-      const next = { ...prev, [key]: !prev[key] };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      return next;
-    });
+    setPreferences((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
   return [preferences, toggle];

--- a/src/hooks/use-indicator-preferences.ts
+++ b/src/hooks/use-indicator-preferences.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "indicator-preferences";
+
+export interface IndicatorPreferences {
+  vwap: boolean;
+  bollinger: boolean;
+  rsi: boolean;
+  macd: boolean;
+  sr: boolean;
+}
+
+const DEFAULT_PREFERENCES: IndicatorPreferences = {
+  vwap: false,
+  bollinger: false,
+  rsi: false,
+  macd: false,
+  sr: false,
+};
+
+export function useIndicatorPreferences(): [
+  IndicatorPreferences,
+  (key: keyof IndicatorPreferences) => void,
+] {
+  const [preferences, setPreferences] =
+    useState<IndicatorPreferences>(DEFAULT_PREFERENCES);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setPreferences({ ...DEFAULT_PREFERENCES, ...(JSON.parse(stored) as Partial<IndicatorPreferences>) });
+      } catch {
+        // ignore malformed stored data
+      }
+    }
+  }, []);
+
+  const toggle = (key: keyof IndicatorPreferences) => {
+    setPreferences((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  };
+
+  return [preferences, toggle];
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -1,0 +1,194 @@
+export interface OHLCVData {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function calcEMA(values: number[], period: number): (number | null)[] {
+  const result: (number | null)[] = new Array(values.length).fill(null);
+  if (values.length < period) return result;
+
+  const multiplier = 2 / (period + 1);
+  let ema = values.slice(0, period).reduce((sum, v) => sum + v, 0) / period;
+  result[period - 1] = ema;
+
+  for (let i = period; i < values.length; i++) {
+    ema = (values[i]! - ema) * multiplier + ema;
+    result[i] = ema;
+  }
+
+  return result;
+}
+
+export function calculateVWAP(
+  data: OHLCVData[],
+): { date: string; vwap: number }[] {
+  let cumTPV = 0;
+  let cumVol = 0;
+
+  return data.map((d) => {
+    const tp = (d.high + d.low + d.close) / 3;
+    cumTPV += tp * d.volume;
+    cumVol += d.volume;
+    return {
+      date: d.date,
+      vwap: cumVol > 0 ? cumTPV / cumVol : tp,
+    };
+  });
+}
+
+export function calculateBollingerBands(
+  data: OHLCVData[],
+  period = 20,
+  multiplier = 2,
+): {
+  date: string;
+  bbUpper: number | null;
+  bbMiddle: number | null;
+  bbLower: number | null;
+}[] {
+  const closes = data.map((d) => d.close);
+
+  return data.map((d, i) => {
+    if (i < period - 1)
+      return { date: d.date, bbUpper: null, bbMiddle: null, bbLower: null };
+
+    const slice = closes.slice(i - period + 1, i + 1);
+    const mean = slice.reduce((s, v) => s + v, 0) / period;
+    const variance =
+      slice.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / period;
+    const std = Math.sqrt(variance);
+
+    return {
+      date: d.date,
+      bbUpper: mean + multiplier * std,
+      bbMiddle: mean,
+      bbLower: mean - multiplier * std,
+    };
+  });
+}
+
+export function calculateRSI(
+  data: OHLCVData[],
+  period = 14,
+): { date: string; rsi: number | null }[] {
+  const closes = data.map((d) => d.close);
+  const result: { date: string; rsi: number | null }[] = data.map((d) => ({
+    date: d.date,
+    rsi: null,
+  }));
+
+  if (closes.length <= period) return result;
+
+  let avgGain = 0;
+  let avgLoss = 0;
+
+  for (let i = 1; i <= period; i++) {
+    const change = closes[i]! - closes[i - 1]!;
+    if (change > 0) avgGain += change;
+    else avgLoss -= change;
+  }
+  avgGain /= period;
+  avgLoss /= period;
+
+  const toRSI = (ag: number, al: number) =>
+    al === 0 ? 100 : 100 - 100 / (1 + ag / al);
+
+  result[period] = { date: data[period]!.date, rsi: toRSI(avgGain, avgLoss) };
+
+  for (let i = period + 1; i < closes.length; i++) {
+    const change = closes[i]! - closes[i - 1]!;
+    avgGain = (avgGain * (period - 1) + Math.max(change, 0)) / period;
+    avgLoss = (avgLoss * (period - 1) + Math.max(-change, 0)) / period;
+    result[i] = { date: data[i]!.date, rsi: toRSI(avgGain, avgLoss) };
+  }
+
+  return result;
+}
+
+export function calculateMACD(
+  data: OHLCVData[],
+  fastPeriod = 12,
+  slowPeriod = 26,
+  signalPeriod = 9,
+): {
+  date: string;
+  macdLine: number | null;
+  macdSignal: number | null;
+  macdHistogram: number | null;
+}[] {
+  const closes = data.map((d) => d.close);
+  const fastEMA = calcEMA(closes, fastPeriod);
+  const slowEMA = calcEMA(closes, slowPeriod);
+
+  const macdValues: (number | null)[] = closes.map((_, i) => {
+    const fast = fastEMA[i];
+    const slow = slowEMA[i];
+    return fast != null && slow != null ? fast - slow : null;
+  });
+
+  const firstValid = macdValues.findIndex((v) => v !== null);
+  const signalEMA: (number | null)[] = new Array(macdValues.length).fill(null);
+
+  if (firstValid !== -1 && macdValues.length - firstValid >= signalPeriod) {
+    const macdNonNull = macdValues.slice(firstValid) as number[];
+    const signalValues = calcEMA(macdNonNull, signalPeriod);
+    signalValues.forEach((v, i) => {
+      signalEMA[firstValid + i] = v;
+    });
+  }
+
+  return data.map((d, i) => ({
+    date: d.date,
+    macdLine: macdValues[i] ?? null,
+    macdSignal: signalEMA[i] ?? null,
+    macdHistogram:
+      macdValues[i] !== null && signalEMA[i] !== null
+        ? macdValues[i]! - signalEMA[i]!
+        : null,
+  }));
+}
+
+export function calculateSupportResistance(
+  data: OHLCVData[],
+  lookback = 5,
+): { date: string; type: "support" | "resistance"; level: number; strength: number }[] {
+  const result: {
+    date: string;
+    type: "support" | "resistance";
+    level: number;
+    strength: number;
+  }[] = [];
+
+  for (let i = lookback; i < data.length - lookback; i++) {
+    const d = data[i]!;
+
+    let isSwingHigh = true;
+    for (let j = i - lookback; j <= i + lookback; j++) {
+      if (j !== i && data[j]!.high >= d.high) {
+        isSwingHigh = false;
+        break;
+      }
+    }
+
+    let isSwingLow = true;
+    for (let j = i - lookback; j <= i + lookback; j++) {
+      if (j !== i && data[j]!.low <= d.low) {
+        isSwingLow = false;
+        break;
+      }
+    }
+
+    if (isSwingHigh) {
+      result.push({ date: d.date, type: "resistance", level: d.high, strength: 1 });
+    }
+    if (isSwingLow) {
+      result.push({ date: d.date, type: "support", level: d.low, strength: 1 });
+    }
+  }
+
+  return result;
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -94,8 +94,10 @@ export function calculateRSI(
   avgGain /= period;
   avgLoss /= period;
 
+  // No price movement yields a neutral RSI value.
+  const NEUTRAL_RSI = 50;
   const toRSI = (ag: number, al: number) => {
-    if (ag === 0 && al === 0) return 50;
+    if (ag === 0 && al === 0) return NEUTRAL_RSI;
     if (al === 0) return 100;
     if (ag === 0) return 0;
     return 100 - 100 / (1 + ag / al);

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -94,8 +94,12 @@ export function calculateRSI(
   avgGain /= period;
   avgLoss /= period;
 
-  const toRSI = (ag: number, al: number) =>
-    al === 0 ? 100 : 100 - 100 / (1 + ag / al);
+  const toRSI = (ag: number, al: number) => {
+    if (ag === 0 && al === 0) return 50;
+    if (al === 0) return 100;
+    if (ag === 0) return 0;
+    return 100 - 100 / (1 + ag / al);
+  };
 
   result[period] = { date: data[period]!.date, rsi: toRSI(avgGain, avgLoss) };
 

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -95,9 +95,9 @@ export function calculateRSI(
   avgLoss /= period;
 
   // No price movement yields a neutral RSI value.
-  const NEUTRAL_RSI = 50;
+  const neutralRsi = 50;
   const toRSI = (ag: number, al: number) => {
-    if (ag === 0 && al === 0) return NEUTRAL_RSI;
+    if (ag === 0 && al === 0) return neutralRsi;
     if (al === 0) return 100;
     if (ag === 0) return 0;
     return 100 - 100 / (1 + ag / al);


### PR DESCRIPTION
## Summary

Adds five toggleable technical indicators to the main stock chart on the dashboard, powered by pure client-side calculations with no additional API calls.

### New files
- **`src/lib/indicators.ts`** — pure functions for each indicator (takes OHLCV array, returns computed data)
- **`src/hooks/use-indicator-preferences.ts`** — localStorage-backed toggle state persisted across sessions

### Modified files
- **`src/components/features/chart.tsx`** — switched from `AreaChart` to `ComposedChart`, added indicator overlays and sub-charts

---

### Indicators implemented

| Indicator | Scale | Render style | Details |
|---|---|---|---|
| **VWAP** | Price | Dashed blue line overlay | Cumulative running VWAP (typical price × volume); shown only for 1M/1W/1D timeframes |
| **Bollinger Bands** | Price | 3-line overlay | 20-period SMA (yellow) ± 2σ upper (red) / lower (green) |
| **RSI** | 0–100 | Sub-chart (90px) | 14-period Wilder RSI; overbought (70) and oversold (30) reference lines |
| **MACD** | Own scale | Sub-chart (90px) | 12/26/9 EMA; MACD line (blue) + signal line (orange dashed) + histogram bars (green/red) |
| **S/R** | Price | Horizontal reference lines | Auto-detected swing highs (resistance, red dashed) and swing lows (support, green dashed) using 5-period lookback; limited to 10 nearest levels |

### UX

- Toggle buttons use the same pill-style as timeframe buttons (`bg-[#424975]` when active)
- All indicators default **OFF**; state persists in `localStorage`
- Indicators with insufficient data (RSI needs 14+, Bollinger 20+, MACD 26+) render nothing silently
- Works with all timeframes (1D through 5Y) including intraday `chartData2`
- Main chart Y-axis uses `auto` domain to accommodate Bollinger band extremes
- Existing price tooltip unchanged (shows only price/date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)