### PR TITLE
feat: add influencer sentiment tracking backend

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,8 @@
  */
 
 import type * as auth from "../auth.js";
+import type * as http from "../http.js";
+import type * as influencer from "../influencer.js";
 import type * as posts from "../posts.js";
 
 import type {
@@ -19,6 +21,8 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
+  http: typeof http;
+  influencer: typeof influencer;
   posts: typeof posts;
 }>;
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,140 @@
+import { httpAction } from "./_generated/server";
+import { httpRouter } from "convex/server";
+import { api } from "./_generated/api";
+
+/**
+ * Public HTTP endpoints for the Go influencer job.
+ * All routes are under /influencer/* and guarded by Authorization: Bearer ${INGEST_SECRET}
+ * Returns {ok: true, result: T} envelope expected by the Go client.
+ */
+
+function checkAuth(req: Request): Response | null {
+  const auth = req.headers.get("authorization");
+  const expected = `Bearer ${process.env.INGEST_SECRET}`;
+  if (auth !== expected) {
+    return jsonResponse(401, { ok: false, error: "Unauthorized" });
+  }
+  return null;
+}
+
+function jsonResponse(status: number, body: any): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function parseBody(req: Request): Promise<any> {
+  try {
+    return await req.json();
+  } catch {
+    return {};
+  }
+}
+
+// ── Main handler (httpAction) ─────────────────────────────────────────────────
+
+export const handleInfluencer = httpAction(async (ctx, req) => {
+  const url = new URL(req.url);
+  const path = url.pathname;
+
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
+
+  try {
+    const route = path.replace(/^\/influencer/, "");
+
+    switch (route) {
+      case "/active": {
+        const influencers = await ctx.runQuery(api.influencer.getActiveInfluencers, {});
+        return jsonResponse(200, { ok: true, result: influencers });
+      }
+
+      case "/seed": {
+        const body = await parseBody(req);
+        const influencers = body.influencers ?? [body];
+        await ctx.runMutation(api.influencer.seedInfluencers, { influencers });
+        return jsonResponse(200, { ok: true, result: null });
+      }
+
+      case "/video/discover": {
+        const body = await parseBody(req);
+        const result = await ctx.runMutation(api.influencer.discoverVideo, body);
+        return jsonResponse(200, { ok: true, result });
+      }
+
+      case "/video/status": {
+        const body = await parseBody(req);
+        await ctx.runMutation(api.influencer.setVideoStatus, body);
+        return jsonResponse(200, { ok: true, result: null });
+      }
+
+      case "/video/error": {
+        const body = await parseBody(req);
+        await ctx.runMutation(api.influencer.setVideoError, body);
+        return jsonResponse(200, { ok: true, result: null });
+      }
+
+      case "/video/result": {
+        const body = await parseBody(req);
+        await ctx.runMutation(api.influencer.saveVideoResult, body);
+        return jsonResponse(200, { ok: true, result: null });
+      }
+
+      case "/aggregate": {
+        const body = await parseBody(req);
+        const result = await ctx.runMutation(api.influencer.aggregateSentiment, body);
+        return jsonResponse(200, { ok: true, result });
+      }
+
+      case "/digest": {
+        const body = await parseBody(req);
+        await ctx.runMutation(api.influencer.saveDigest, body);
+        return jsonResponse(200, { ok: true, result: null });
+      }
+
+      case "/purge": {
+        const body = await parseBody(req);
+        const result = await ctx.runMutation(api.influencer.purgeOld, body);
+        return jsonResponse(200, { ok: true, result });
+      }
+
+      case "/run/start": {
+        const body = await parseBody(req);
+        const result = await ctx.runMutation(api.influencer.startJobRun, body);
+        return jsonResponse(200, { ok: true, result: result.id });
+      }
+
+      case "/run/finish": {
+        const body = await parseBody(req);
+        await ctx.runMutation(api.influencer.endJobRun, body);
+        return jsonResponse(200, { ok: true, result: null });
+      }
+
+      default:
+        return jsonResponse(404, { ok: false, error: `Unknown route: ${route} (full path: ${path})` });
+    }
+  } catch (e: any) {
+    console.error("Ingest error:", e);
+    return jsonResponse(500, { ok: false, error: e.message ?? "Internal error" });
+  }
+});
+
+// ── Router definition ────────────────────────────────────────────────────────
+
+const http = httpRouter();
+
+// Mount everything under /influencer/* — both GET and POST
+http.route({
+  path: "/influencer/*",
+  method: "POST",
+  handler: handleInfluencer,
+});
+
+http.route({
+  path: "/influencer/active",
+  method: "GET",
+  handler: handleInfluencer,
+});
+
+export default http;

--- a/convex/influencer.ts
+++ b/convex/influencer.ts
@@ -1,0 +1,555 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Influencer sentiment tracking — mutations and queries.
+ */
+
+// ── Seed / manage influencers ───────────────────────────────────────────────
+
+export const seedInfluencers = mutation({
+  args: {
+    influencers: v.array(
+      v.object({
+        name: v.string(),
+        channelId: v.string(),
+        handle: v.optional(v.string()),
+        avatar: v.optional(v.string()),
+        active: v.optional(v.boolean()),
+      })
+    ),
+  },
+  handler: async (ctx, { influencers }) => {
+    for (const inf of influencers) {
+      const existing = await ctx.db
+        .query("influencers")
+        .withIndex("by_channelId", (q) => q.eq("channelId", inf.channelId))
+        .first();
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          name: inf.name,
+          handle: inf.handle,
+          avatar: inf.avatar,
+          active: inf.active ?? true,
+        });
+      } else {
+        await ctx.db.insert("influencers", {
+          name: inf.name,
+          channelId: inf.channelId,
+          handle: inf.handle,
+          avatar: inf.avatar,
+          active: inf.active ?? true,
+        });
+      }
+    }
+  },
+});
+
+export const getActiveInfluencers = query({
+  handler: async (ctx) => {
+    return await ctx.db
+      .query("influencers")
+      .withIndex("by_active", (q) => q.eq("active", true))
+      .collect();
+  },
+});
+
+// ── Video discovery ─────────────────────────────────────────────────────────
+
+export const discoverVideo = mutation({
+  args: {
+    channelId: v.string(),
+    videoId: v.string(),
+    title: v.string(),
+    url: v.optional(v.string()),
+    publishedAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("influencerVideos")
+      .withIndex("by_videoId", (q) => q.eq("videoId", args.videoId))
+      .first();
+    if (existing) {
+      return { id: existing._id, influencerId: existing.channelId, isNew: false, status: existing.status };
+    }
+    const id = await ctx.db.insert("influencerVideos", {
+      videoId: args.videoId,
+      channelId: args.channelId,
+      title: args.title,
+      status: "pending",
+      publishedAt: args.publishedAt,
+    });
+    return { id, influencerId: args.channelId, isNew: true, status: "pending" };
+  },
+});
+
+export const setVideoStatus = mutation({
+  args: {
+    videoId: v.string(),
+    status: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const video = await ctx.db
+      .query("influencerVideos")
+      .withIndex("by_videoId", (q) => q.eq("videoId", args.videoId))
+      .first();
+    if (!video) throw new Error(`Video not found: ${args.videoId}`);
+    await ctx.db.patch(video._id, { status: args.status });
+  },
+});
+
+export const setVideoError = mutation({
+  args: {
+    videoId: v.string(),
+    error: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const video = await ctx.db
+      .query("influencerVideos")
+      .withIndex("by_videoId", (q) => q.eq("videoId", args.videoId))
+      .first();
+    if (!video) throw new Error(`Video not found: ${args.videoId}`);
+    await ctx.db.patch(video._id, { status: "failed", summary: args.error });
+  },
+});
+
+// ── Save video result ───────────────────────────────────────────────────────
+
+export const saveVideoResult = mutation({
+  args: {
+    videoId: v.string(),
+    transcript: v.optional(v.string()),
+    summary: v.optional(v.string()),
+    mentions: v.optional(
+      v.array(
+        v.object({
+          symbol: v.string(),
+          companyName: v.optional(v.string()),
+          stance: v.union(
+            v.literal("bullish"),
+            v.literal("bearish"),
+            v.literal("neutral")
+          ),
+          conviction: v.union(
+            v.literal("high"),
+            v.literal("medium"),
+            v.literal("low")
+          ),
+          thesis: v.string(),
+          action: v.optional(v.string()),
+          priceTarget: v.optional(v.number()),
+          timeframe: v.optional(v.string()),
+        })
+      )
+    ),
+    macro: v.optional(
+      v.object({
+        macroSummary: v.string(),
+        sentiment: v.optional(v.string()),
+        sectorViews: v.optional(v.array(v.object({
+          sector: v.string(),
+          stance: v.string(),
+          note: v.optional(v.string()),
+        }))),
+        rotations: v.optional(v.array(v.object({
+          from: v.optional(v.string()),
+          to: v.optional(v.string()),
+          note: v.string(),
+        }))),
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    const video = await ctx.db
+      .query("influencerVideos")
+      .withIndex("by_videoId", (q) => q.eq("videoId", args.videoId))
+      .first();
+    if (!video) throw new Error(`Video not found: ${args.videoId}`);
+
+    const patch: any = { status: "done", processedAt: Date.now() };
+    if (args.transcript) patch.transcript = args.transcript;
+    if (args.summary) patch.summary = args.summary;
+    await ctx.db.patch(video._id, patch);
+
+    if (args.mentions) {
+      for (const m of args.mentions) {
+        await ctx.db.insert("videoStockMentions", {
+          videoId: args.videoId,
+          channelId: video.channelId,
+          symbol: m.symbol,
+          stance: m.stance,
+          conviction: m.conviction,
+          thesis: m.thesis,
+          action: m.action,
+          priceTarget: m.priceTarget?.toString?.(),
+        });
+      }
+    }
+
+    if (args.macro) {
+      await ctx.db.insert("macroNotes", {
+        videoId: args.videoId,
+        channelId: video.channelId,
+        macroSummary: args.macro.macroSummary,
+        sectorViews: args.macro.sectorViews?.map((s: any) => s.sector ?? s).filter(Boolean) ?? [],
+        rotations: args.macro.rotations?.map((r: any) => `${r.from ?? "?"} → ${r.to ?? "?"}: ${r.note}`).filter(Boolean) ?? [],
+      });
+    }
+
+    return { ok: true };
+  },
+});
+
+// ── Aggregation ───────────────────────────────────────────────────────────────
+
+export const aggregateSentiment = mutation({
+  args: {
+    date: v.optional(v.string()),
+    windowDays: v.number(),
+  },
+  handler: async (ctx, { windowDays }) => {
+    const now = Date.now();
+    const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
+
+    const mentions = await ctx.db.query("videoStockMentions").collect();
+    const videos = await ctx.db.query("influencerVideos").collect();
+    const videoInWindow = new Set(
+      videos.filter((v) => v.publishedAt >= cutoff).map((v) => v.videoId)
+    );
+    const windowMentions = mentions.filter((m) => videoInWindow.has(m.videoId));
+
+    const bySymbol: Record<
+      string,
+      { bullish: Set<string>; bearish: Set<string>; neutral: Set<string>; theses: any[]; netScore: number }
+    > = {};
+
+    for (const m of windowMentions) {
+      if (!bySymbol[m.symbol]) {
+        bySymbol[m.symbol] = {
+          bullish: new Set(),
+          bearish: new Set(),
+          neutral: new Set(),
+          theses: [],
+          netScore: 0,
+        };
+      }
+      bySymbol[m.symbol][m.stance].add(m.channelId);
+      bySymbol[m.symbol].theses.push({ influencerId: m.channelId, stance: m.stance, thesis: m.thesis });
+
+      const weight = m.stance === "bullish" ? 1 : m.stance === "bearish" ? -1 : 0;
+      const conv = m.conviction === "high" ? 3 : m.conviction === "medium" ? 2 : 1;
+      bySymbol[m.symbol].netScore += weight * conv;
+    }
+
+    const endDate = new Date(now).toISOString().split("T")[0];
+
+    // Clear old sentiment
+    const old = await ctx.db.query("dailySentiment").collect();
+    for (const row of old) await ctx.db.delete(row._id);
+
+    const bullishLeaders: any[] = [];
+    const bearishLeaders: any[] = [];
+
+    for (const [symbol, data] of Object.entries(bySymbol)) {
+      const bullish = data.bullish.size;
+      const bearish = data.bearish.size;
+      const neutral = data.neutral.size;
+      const total = bullish + bearish;
+
+      let consensus: any = "mixed";
+      if (total > 0) {
+        const ratio = bullish / total;
+        if (ratio >= 0.7) consensus = "strong_bullish";
+        else if (ratio >= 0.55) consensus = "bullish";
+        else if (ratio <= 0.3) consensus = "strong_bearish";
+        else if (ratio <= 0.45) consensus = "bearish";
+      }
+
+      const theses = data.theses.slice(0, 5);
+
+      await ctx.db.insert("dailySentiment", {
+        symbol,
+        date: endDate,
+        bullishCount: bullish,
+        bearishCount: bearish,
+        neutralCount: neutral,
+        bullishCreators: Array.from(data.bullish),
+        bearishCreators: Array.from(data.bearish),
+        netScore: data.netScore,
+        consensus,
+        strongestTheses: theses.map((t: any) => t.thesis),
+        windowStart: new Date(cutoff).toISOString().split("T")[0],
+        windowEnd: endDate,
+      });
+
+      const leader = {
+        symbol,
+        companyName: null,
+        netScore: data.netScore,
+        bullish,
+        bearish,
+        neutral,
+        mentions: bullish + bearish + neutral,
+        consensus,
+        theses,
+      };
+
+      if (consensus === "bullish" || consensus === "strong_bullish") {
+        bullishLeaders.push(leader);
+      } else if (consensus === "bearish" || consensus === "strong_bearish") {
+        bearishLeaders.push(leader);
+      }
+    }
+
+    bullishLeaders.sort((a, b) => b.bullish - a.bullish);
+    bearishLeaders.sort((a, b) => b.bearish - a.bearish);
+
+    // Get macro notes
+    const macroNotesRaw = await ctx.db.query("macroNotes").collect();
+    const macroNotes = macroNotesRaw
+      .filter((m) => videoInWindow.has(m.videoId))
+      .map((m) => ({
+        influencerId: m.channelId,
+        macroSummary: m.macroSummary,
+        sentiment: null,
+        sectorViews: [] as any[],
+        rotations: [] as any[],
+      }));
+
+    return {
+      date: endDate,
+      windowDays,
+      symbolCount: Object.keys(bySymbol).length,
+      bullishLeaders,
+      bearishLeaders,
+      macroNotes,
+    };
+  },
+});
+
+// ── Save digest ──────────────────────────────────────────────────────────────
+
+export const saveDigest = mutation({
+  args: {
+    date: v.string(),
+    marketSentiment: v.string(),
+    sentimentLabel: v.optional(v.string()),
+    keyThemes: v.array(v.string()),
+    sectorRotation: v.optional(v.array(v.object({
+      from: v.optional(v.string()),
+      to: v.optional(v.string()),
+      rationale: v.string(),
+    }))),
+    bullishLeaders: v.optional(v.array(v.object({
+      symbol: v.string(),
+      netScore: v.number(),
+      mentions: v.number(),
+    }))),
+    bearishLeaders: v.optional(v.array(v.object({
+      symbol: v.string(),
+      netScore: v.number(),
+      mentions: v.number(),
+    }))),
+    recommendedActions: v.optional(v.array(v.object({
+      symbol: v.optional(v.string()),
+      action: v.string(),
+      rationale: v.string(),
+    }))),
+    videosAnalyzed: v.optional(v.number()),
+    influencersCount: v.optional(v.number()),
+    windowDays: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("macroDigest")
+      .withIndex("by_date", (q) => q.eq("date", args.date))
+      .first();
+
+    const digest = {
+      date: args.date,
+      marketSentiment: args.marketSentiment,
+      keyThemes: args.keyThemes,
+      sectorRotations: args.sectorRotation?.map((r: any) => `${r.from ?? "?"} → ${r.to ?? "?"}: ${r.rationale}`) ?? [],
+      bullishLeaders: args.bullishLeaders?.map((l: any) => l.symbol) ?? [],
+      bearishLeaders: args.bearishLeaders?.map((l: any) => l.symbol) ?? [],
+      recommendedActions: args.recommendedActions?.map((a: any) => `${a.action} — ${a.rationale}`) ?? [],
+      createdAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, digest);
+      return { id: existing._id };
+    }
+
+    const id = await ctx.db.insert("macroDigest", digest);
+    return { id };
+  },
+});
+
+// ── Purge old data ──────────────────────────────────────────────────────────
+
+export const purgeOld = mutation({
+  args: {
+    olderThanDays: v.number(),
+  },
+  handler: async (ctx, { olderThanDays }) => {
+    const cutoff = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+
+    const videos = await ctx.db.query("influencerVideos").collect();
+    let videosPurged = 0;
+    let mentionsPurged = 0;
+    let macrosPurged = 0;
+
+    for (const v of videos) {
+      if (v.publishedAt < cutoff) {
+        const mentions = await ctx.db
+          .query("videoStockMentions")
+          .withIndex("by_videoId", (q) => q.eq("videoId", v.videoId))
+          .collect();
+        for (const m of mentions) {
+          await ctx.db.delete(m._id);
+          mentionsPurged++;
+        }
+
+        const macros = await ctx.db
+          .query("macroNotes")
+          .withIndex("by_videoId", (q) => q.eq("videoId", v.videoId))
+          .collect();
+        for (const m of macros) {
+          await ctx.db.delete(m._id);
+          macrosPurged++;
+        }
+
+        await ctx.db.delete(v._id);
+        videosPurged++;
+      }
+    }
+
+    const digests = await ctx.db.query("macroDigest").collect();
+    let digestsPurged = 0;
+    for (const d of digests) {
+      const digestDate = new Date(d.date).getTime();
+      if (digestDate < cutoff) {
+        await ctx.db.delete(d._id);
+        digestsPurged++;
+      }
+    }
+
+    return {
+      videos: videosPurged,
+      mentions: mentionsPurged,
+      macros: macrosPurged,
+      digests: digestsPurged,
+      sentiment: 0, // sentiment is cleared by aggregate
+    };
+  },
+});
+
+// ── Job run tracking ─────────────────────────────────────────────────────────
+
+export const startJobRun = mutation({
+  args: {
+    mode: v.string(),
+    startedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("jobRuns", {
+      mode: args.mode,
+      status: "running",
+      startedAt: args.startedAt ?? Date.now(),
+    });
+    return { id };
+  },
+});
+
+export const endJobRun = mutation({
+  args: {
+    runId: v.string(),
+    status: v.union(v.literal("success"), v.literal("failed")),
+    videosDiscovered: v.optional(v.number()),
+    videosProcessed: v.optional(v.number()),
+    videosErrored: v.optional(v.number()),
+    error: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // runId is actually the Convex document ID string
+    const run = await ctx.db.get(args.runId as any);
+    if (!run) throw new Error(`Job run not found: ${args.runId}`);
+
+    await ctx.db.patch(run._id, {
+      status: args.status,
+      videosDiscovered: args.videosDiscovered,
+      videosProcessed: args.videosProcessed,
+      videosFailed: args.videosErrored,
+      endedAt: Date.now(),
+      errorMessage: args.error,
+    });
+    return { ok: true };
+  },
+});
+
+// ── Read queries ────────────────────────────────────────────────────────────
+
+export const getInfluencers = query({
+  handler: async (ctx) => {
+    return await ctx.db.query("influencers").collect();
+  },
+});
+
+export const latestDigest = query({
+  handler: async (ctx) => {
+    const digests = await ctx.db.query("macroDigest").collect();
+    if (digests.length === 0) return null;
+    return digests.sort((a, b) => b.createdAt - a.createdAt)[0];
+  },
+});
+
+export const sentimentRanking = query({
+  handler: async (ctx) => {
+    const sentiments = await ctx.db.query("dailySentiment").collect();
+    const bullish = sentiments
+      .filter((s) => s.consensus === "strong_bullish" || s.consensus === "bullish")
+      .sort((a, b) => b.bullishCount - a.bullishCount);
+    const bearish = sentiments
+      .filter((s) => s.consensus === "strong_bearish" || s.consensus === "bearish")
+      .sort((a, b) => b.bearishCount - a.bearishCount);
+    const mixed = sentiments.filter((s) => s.consensus === "mixed");
+
+    return { bullish, bearish, mixed };
+  },
+});
+
+export const recentVideos = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const videos = await ctx.db
+      .query("influencerVideos")
+      .withIndex("by_publishedAt")
+      .collect();
+    return videos.sort((a, b) => b.publishedAt - a.publishedAt).slice(0, args.limit ?? 20);
+  },
+});
+
+export const videosByChannel = query({
+  args: { channelId: v.string() },
+  handler: async (ctx, { channelId }) => {
+    const videos = await ctx.db
+      .query("influencerVideos")
+      .withIndex("by_channelId", (q) => q.eq("channelId", channelId))
+      .collect();
+    return videos.sort((a, b) => b.publishedAt - a.publishedAt);
+  },
+});
+
+export const latestRun = query({
+  handler: async (ctx) => {
+    const runs = await ctx.db
+      .query("jobRuns")
+      .withIndex("by_startedAt")
+      .collect();
+    if (runs.length === 0) return null;
+    return runs.sort((a, b) => b.startedAt - a.startedAt)[0];
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -73,4 +73,157 @@ export default defineSchema({
     token: v.string(),
     expires: v.number(), // timestamp as ms
   }).index("by_identifier_token", ["identifier", "token"]),
+
+  // ── Influencer sentiment tables ─────────────────────────────────────────
+
+  influencers: defineTable({
+    name: v.string(),
+    channelId: v.string(),
+    handle: v.optional(v.string()),
+    avatar: v.optional(v.string()),
+    active: v.boolean(),
+    // Legacy fields
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  })
+    .index("by_channelId", ["channelId"])
+    .index("by_active", ["active"]),
+
+  influencerVideos: defineTable({
+    videoId: v.string(),
+    channelId: v.string(),
+    title: v.string(),
+    thumbnail: v.optional(v.string()),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("transcribing"),
+      v.literal("analyzing"),
+      v.literal("done"),
+      v.literal("failed")
+    ),
+    transcript: v.optional(v.string()),
+    summary: v.optional(v.string()),
+    publishedAt: v.number(), // timestamp as ms
+    processedAt: v.optional(v.number()), // timestamp as ms
+    // Legacy fields from previous runs
+    createdAt: v.optional(v.number()),
+    influencerId: v.optional(v.string()),
+    updatedAt: v.optional(v.number()),
+    url: v.optional(v.string()),
+  })
+    .index("by_videoId", ["videoId"])
+    .index("by_channelId", ["channelId"])
+    .index("by_status", ["status"])
+    .index("by_publishedAt", ["publishedAt"]),
+
+  videoStockMentions: defineTable({
+    videoId: v.string(),
+    channelId: v.optional(v.string()),
+    symbol: v.string(),
+    stance: v.union(
+      v.literal("bullish"),
+      v.literal("bearish"),
+      v.literal("neutral")
+    ),
+    conviction: v.union(
+      v.literal("high"),
+      v.literal("medium"),
+      v.literal("low")
+    ),
+    thesis: v.string(),
+    action: v.optional(v.string()),
+    priceTarget: v.optional(v.union(v.string(), v.number())),
+    // Legacy fields
+    companyName: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    influencerId: v.optional(v.string()),
+    publishedAt: v.optional(v.number()),
+    timeframe: v.optional(v.string()),
+  })
+    .index("by_videoId", ["videoId"])
+    .index("by_symbol", ["symbol"])
+    .index("by_channelId", ["channelId"]),
+
+  macroNotes: defineTable({
+    videoId: v.string(),
+    channelId: v.optional(v.string()),
+    macroSummary: v.string(),
+    sectorViews: v.optional(v.array(v.any())),
+    rotations: v.optional(v.array(v.any())),
+    // Legacy fields
+    createdAt: v.optional(v.number()),
+    influencerId: v.optional(v.string()),
+    publishedAt: v.optional(v.number()),
+    sentiment: v.optional(v.string()),
+  })
+    .index("by_videoId", ["videoId"])
+    .index("by_channelId", ["channelId"]),
+
+  dailySentiment: defineTable({
+    symbol: v.string(),
+    date: v.string(), // YYYY-MM-DD
+    bullishCount: v.optional(v.number()),
+    bearishCount: v.optional(v.number()),
+    neutralCount: v.optional(v.number()),
+    bullishCreators: v.optional(v.array(v.string())),
+    bearishCreators: v.optional(v.array(v.string())),
+    netScore: v.optional(v.number()), // conviction-weighted
+    consensus: v.optional(v.union(
+      v.literal("strong_bullish"),
+      v.literal("bullish"),
+      v.literal("mixed"),
+      v.literal("bearish"),
+      v.literal("strong_bearish")
+    )),
+    strongestTheses: v.optional(v.array(v.string())),
+    windowStart: v.optional(v.string()), // YYYY-MM-DD
+    windowEnd: v.optional(v.string()), // YYYY-MM-DD
+    // Legacy fields from previous runs
+    companyName: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    influencerIds: v.optional(v.array(v.string())),
+    mentionsCount: v.optional(v.number()),
+    neutralCreators: v.optional(v.array(v.string())),
+    topTheses: v.optional(v.array(v.any())),
+    windowDays: v.optional(v.number()),
+  })
+    .index("by_symbol", ["symbol"])
+    .index("by_date", ["date"])
+    .index("by_symbol_date", ["symbol", "date"]),
+
+  macroDigest: defineTable({
+    date: v.string(), // YYYY-MM-DD
+    marketSentiment: v.string(),
+    keyThemes: v.optional(v.array(v.string())),
+    sectorRotations: v.optional(v.array(v.string())),
+    bullishLeaders: v.optional(v.array(v.any())),
+    bearishLeaders: v.optional(v.array(v.any())),
+    recommendedActions: v.optional(v.array(v.any())),
+    createdAt: v.number(), // timestamp as ms
+    // Legacy fields
+    influencersCount: v.optional(v.number()),
+    videosAnalyzed: v.optional(v.number()),
+    windowDays: v.optional(v.number()),
+    runAt: v.optional(v.number()),
+    sentimentLabel: v.optional(v.string()),
+    sectorRotation: v.optional(v.array(v.any())),
+  })
+    .index("by_date", ["date"])
+    .index("by_createdAt", ["createdAt"]),
+
+  jobRuns: defineTable({
+    mode: v.string(),
+    status: v.union(v.literal("running"), v.literal("success"), v.literal("failed")),
+    videosDiscovered: v.optional(v.number()),
+    videosProcessed: v.optional(v.number()),
+    videosFailed: v.optional(v.number()),
+    startedAt: v.optional(v.number()),
+    endedAt: v.optional(v.number()),
+    errorMessage: v.optional(v.string()),
+    // Legacy fields
+    finishedAt: v.optional(v.number()),
+    runAt: v.optional(v.number()),
+    videosErrored: v.optional(v.number()),
+  })
+    .index("by_startedAt", ["startedAt"]),
 });

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -1,18 +1,31 @@
 "use client";
 
 import { LoaderCircle } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
+  Area,
+  Bar,
   CartesianGrid,
-  AreaChart,
+  Cell,
+  ComposedChart,
+  Line,
+  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis,
-  Area,
 } from "recharts";
 
 import { ChartTooltip } from "~/components/ui/chart";
+import { useIndicatorPreferences } from "~/hooks/use-indicator-preferences";
 import { useSymbol } from "~/hooks/use-symbol";
+import {
+  calculateBollingerBands,
+  calculateMACD,
+  calculateRSI,
+  calculateSupportResistance,
+  calculateVWAP,
+  type OHLCVData,
+} from "~/lib/indicators";
 import { api } from "~/trpc/react";
 
 const PriceChange = ({ data }: { data?: { price: number }[] }) => {
@@ -86,30 +99,33 @@ const CustomTooltip = ({
 
 type TimeFrame = "5Y" | "1Y" | "6M" | "1M" | "1W" | "1D";
 
-const filterDataByTimeFrame = (
-  data: {
-    date: string;
-    price: number;
-  }[],
+const VWAP_TIMEFRAMES: TimeFrame[] = ["1M", "1W", "1D"];
+
+interface ChartDataPoint extends OHLCVData {
+  price: number;
+}
+
+const filterDataByTimeFrame = <T extends { date: string }>(
+  data: T[],
   timeFrame: TimeFrame,
-) => {
+): T[] => {
   const sortedData = [...data].sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   );
 
   switch (timeFrame) {
     case "5Y":
-      return sortedData.slice(-252 * 5); // ~252 trading days per year
+      return sortedData.slice(-252 * 5);
     case "1Y":
       return sortedData.slice(-252);
     case "6M":
-      return sortedData.slice(-126); // ~21 trading days * 6
+      return sortedData.slice(-126);
     case "1M":
-      return sortedData.slice(-21); // ~21 trading days
+      return sortedData.slice(-21);
     case "1W":
-      return sortedData.slice(-5); // 5 trading days
+      return sortedData.slice(-5);
     case "1D":
-      return sortedData.slice(-1); // Latest day
+      return sortedData.slice(-1);
     default:
       return sortedData;
   }
@@ -118,6 +134,8 @@ const filterDataByTimeFrame = (
 export function Chart() {
   const [timeFrame, setTimeFrame] = useState<TimeFrame>("1Y");
   const [symbol] = useSymbol();
+  const [indicators, toggleIndicator] = useIndicatorPreferences();
+
   const { data, isLoading } = api.asset.equityPriceHistoricalFMP.useQuery(
     symbol ?? "",
     {
@@ -136,29 +154,118 @@ export function Chart() {
       enabled: timeFrame === "1D" && !!symbol,
     });
 
-  if (!symbol) {
-    return <NoSymbolMessage />;
-  }
+  const chartData: ChartDataPoint[] = useMemo(() => {
+    if (!data?.historical) return [];
+    return [...data.historical]
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      .map((r) => ({
+        date: r.date,
+        price: r.close,
+        open: r.open,
+        high: r.high,
+        low: r.low,
+        close: r.close,
+        volume: r.volume,
+      }));
+  }, [data]);
 
-  if (isLoading || isLoading2) {
-    return <ChartSkeleton />;
-  }
-
-  const chartData = data?.historical
-    ?.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-    .map((result) => ({
-      date: result.date,
-      price: result.close,
+  const chartData2: ChartDataPoint[] = useMemo(() => {
+    if (!data2?.results) return [];
+    return data2.results.map((r) => ({
+      date: r.date,
+      price: r.close,
+      open: r.open,
+      high: r.high,
+      low: r.low,
+      close: r.close,
+      volume: r.volume,
     }));
+  }, [data2]);
 
-  const chartData2 = data2?.results?.map((result) => ({
-    date: result.date,
-    price: result.close,
-  }));
+  const activeChartData: ChartDataPoint[] = useMemo(() => {
+    if (timeFrame === "1D") return chartData2;
+    return filterDataByTimeFrame(chartData, timeFrame);
+  }, [timeFrame, chartData, chartData2]);
 
-  const filteredData = chartData
-    ? filterDataByTimeFrame(chartData ?? [], timeFrame)
-    : [];
+  const indicatorData = useMemo(() => {
+    if (!activeChartData.length) return null;
+    return {
+      vwap: calculateVWAP(activeChartData),
+      bollinger: calculateBollingerBands(activeChartData),
+      rsi: calculateRSI(activeChartData),
+      macd: calculateMACD(activeChartData),
+      sr: calculateSupportResistance(activeChartData),
+    };
+  }, [activeChartData]);
+
+  const showVWAP = indicators.vwap && VWAP_TIMEFRAMES.includes(timeFrame);
+
+  const mergedData = useMemo(() => {
+    if (!indicatorData) return activeChartData;
+    return activeChartData.map((d, i) => ({
+      ...d,
+      ...(showVWAP ? { vwap: indicatorData.vwap[i]?.vwap } : {}),
+      ...(indicators.bollinger
+        ? {
+            bbUpper: indicatorData.bollinger[i]?.bbUpper,
+            bbMiddle: indicatorData.bollinger[i]?.bbMiddle,
+            bbLower: indicatorData.bollinger[i]?.bbLower,
+          }
+        : {}),
+      ...(indicators.rsi ? { rsi: indicatorData.rsi[i]?.rsi } : {}),
+      ...(indicators.macd
+        ? {
+            macdLine: indicatorData.macd[i]?.macdLine,
+            macdSignal: indicatorData.macd[i]?.macdSignal,
+            macdHistogram: indicatorData.macd[i]?.macdHistogram,
+          }
+        : {}),
+    }));
+  }, [activeChartData, indicatorData, showVWAP, indicators]);
+
+  const srLevels = useMemo(() => {
+    if (!indicatorData || !indicators.sr || !activeChartData.length) return [];
+    const prices = activeChartData.map((d) => d.price);
+    const minPrice = Math.min(...prices);
+    const maxPrice = Math.max(...prices);
+    const range = maxPrice - minPrice;
+    return indicatorData.sr
+      .filter(
+        (lvl) =>
+          lvl.level >= minPrice - range * 0.05 &&
+          lvl.level <= maxPrice + range * 0.05,
+      )
+      .slice(0, 10);
+  }, [indicatorData, indicators.sr, activeChartData]);
+
+  const showRSI = indicators.rsi;
+  const showMACD = indicators.macd;
+  const hasSubCharts = showRSI || showMACD;
+
+  if (!symbol) return <NoSymbolMessage />;
+  if (isLoading || isLoading2) return <ChartSkeleton />;
+
+  const indicatorButtons: { key: keyof typeof indicators; label: string }[] = [
+    { key: "vwap", label: "VWAP" },
+    { key: "bollinger", label: "Bollinger" },
+    { key: "rsi", label: "RSI" },
+    { key: "macd", label: "MACD" },
+    { key: "sr", label: "S/R" },
+  ];
+
+  const tickFormatter = (value: string) => {
+    const date = new Date(value);
+    if (timeFrame === "1D")
+      return date.toLocaleString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    return date.toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: date.getMonth() === 0 ? "numeric" : undefined,
+    });
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -184,60 +291,230 @@ export function Chart() {
             </button>
           ))}
         </div>
-        <PriceChange data={timeFrame === "1D" ? chartData2 : filteredData} />
+        <PriceChange
+          data={timeFrame === "1D" ? chartData2 : activeChartData}
+        />
       </div>
 
-      <ResponsiveContainer>
-        <AreaChart
-          accessibilityLayer
-          data={timeFrame === "1D" ? chartData2 : filteredData}
-        >
-          <defs>
-            <linearGradient id="colorPv" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
-              <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
-            </linearGradient>
-          </defs>
-
-          <CartesianGrid vertical={false} />
-          <XAxis
-            fontSize={12}
-            dataKey="date"
-            minTickGap={50}
-            interval="preserveStartEnd"
-            tickFormatter={(value: string) => {
-              const date = new Date(value);
-
-              if (timeFrame === "1D")
-                return date.toLocaleString("en-US", {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-
-              return date.toLocaleString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: date.getMonth() === 0 ? "numeric" : undefined,
-              });
+      <div className="flex gap-2 px-2 pb-2">
+        {indicatorButtons.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleIndicator(key);
             }}
-          />
-          <YAxis
-            fontSize={12}
-            dataKey="price"
-            type="number"
-            domain={["dataMin", "dataMax"]}
-            tickFormatter={(value: number) => value?.toFixed(2)}
-          />
-          <ChartTooltip content={<CustomTooltip />} />
-          <Area
-            dataKey="price"
-            stroke="#82ca9d"
-            fillOpacity={1}
-            fill="url(#colorPv)"
-            dot={false}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+            className={`rounded px-3 py-1 text-xs ${
+              indicators[key]
+                ? "bg-[#424975] text-white"
+                : "bg-transparent text-gray-500 hover:bg-[#424975]/50"
+            }`}
+            style={{ zIndex: 100 }}
+            onTouchStart={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            accessibilityLayer
+            data={mergedData}
+            margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+          >
+            <defs>
+              <linearGradient id="colorPv" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+
+            <CartesianGrid vertical={false} />
+            <XAxis
+              fontSize={12}
+              dataKey="date"
+              minTickGap={50}
+              interval="preserveStartEnd"
+              tickFormatter={tickFormatter}
+            />
+            <YAxis
+              fontSize={12}
+              type="number"
+              domain={["auto", "auto"]}
+              tickFormatter={(value: number) => value?.toFixed(2)}
+              width={65}
+            />
+            <ChartTooltip content={<CustomTooltip />} />
+
+            <Area
+              dataKey="price"
+              stroke="#82ca9d"
+              fillOpacity={1}
+              fill="url(#colorPv)"
+              dot={false}
+              isAnimationActive={false}
+            />
+
+            {showVWAP && (
+              <Line
+                dataKey="vwap"
+                stroke="#3b82f6"
+                strokeWidth={1.5}
+                strokeDasharray="5 5"
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            )}
+
+            {indicators.bollinger && (
+              <>
+                <Line
+                  dataKey="bbUpper"
+                  stroke="#ef4444"
+                  strokeWidth={1}
+                  strokeOpacity={0.6}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls={false}
+                />
+                <Line
+                  dataKey="bbMiddle"
+                  stroke="#eab308"
+                  strokeWidth={1}
+                  strokeOpacity={0.6}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls={false}
+                />
+                <Line
+                  dataKey="bbLower"
+                  stroke="#22c55e"
+                  strokeWidth={1}
+                  strokeOpacity={0.6}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls={false}
+                />
+              </>
+            )}
+
+            {indicators.sr &&
+              srLevels.map((lvl, idx) => (
+                <ReferenceLine
+                  key={`${lvl.type}-${idx}`}
+                  y={lvl.level}
+                  stroke={lvl.type === "support" ? "#22c55e" : "#ef4444"}
+                  strokeDasharray="4 4"
+                  strokeOpacity={0.7}
+                  label={{
+                    value: lvl.type === "support" ? "S" : "R",
+                    position: "insideTopRight",
+                    fontSize: 10,
+                    fill: lvl.type === "support" ? "#22c55e" : "#ef4444",
+                  }}
+                />
+              ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {showRSI && (
+        <div style={{ height: 90 }}>
+          <div className="px-2 pt-1 text-xs text-gray-400">RSI (14)</div>
+          <ResponsiveContainer width="100%" height={72}>
+            <ComposedChart
+              data={mergedData}
+              margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+            >
+              <XAxis dataKey="date" hide />
+              <YAxis
+                domain={[0, 100]}
+                ticks={[30, 70]}
+                fontSize={10}
+                width={65}
+              />
+              <ReferenceLine
+                y={70}
+                stroke="#ef4444"
+                strokeDasharray="3 3"
+                strokeOpacity={0.5}
+              />
+              <ReferenceLine
+                y={30}
+                stroke="#22c55e"
+                strokeDasharray="3 3"
+                strokeOpacity={0.5}
+              />
+              <Line
+                dataKey="rsi"
+                stroke="#a855f7"
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {showMACD && (
+        <div style={{ height: 90 }}>
+          <div className="px-2 pt-1 text-xs text-gray-400">MACD (12,26,9)</div>
+          <ResponsiveContainer width="100%" height={72}>
+            <ComposedChart
+              data={mergedData}
+              margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+            >
+              <XAxis dataKey="date" hide />
+              <YAxis fontSize={10} width={65} />
+              <ReferenceLine y={0} stroke="#6b7280" strokeOpacity={0.4} />
+              <Bar
+                dataKey="macdHistogram"
+                isAnimationActive={false}
+                maxBarSize={4}
+              >
+                {mergedData.map((entry, idx) => {
+                  const val = (
+                    entry as unknown as Record<string, number | null | undefined>
+                  ).macdHistogram;
+                  return (
+                    <Cell
+                      key={`macd-cell-${idx}`}
+                      fill={
+                        val != null && val >= 0 ? "#22c55e" : "#ef4444"
+                      }
+                    />
+                  );
+                })}
+              </Bar>
+              <Line
+                dataKey="macdLine"
+                stroke="#3b82f6"
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+              <Line
+                dataKey="macdSignal"
+                stroke="#f97316"
+                strokeWidth={1.5}
+                strokeDasharray="3 3"
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {!hasSubCharts && <div />}
     </div>
   );
 }

--- a/src/hooks/use-indicator-preferences.ts
+++ b/src/hooks/use-indicator-preferences.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "indicator-preferences";
+
+export interface IndicatorPreferences {
+  vwap: boolean;
+  bollinger: boolean;
+  rsi: boolean;
+  macd: boolean;
+  sr: boolean;
+}
+
+const DEFAULT_PREFERENCES: IndicatorPreferences = {
+  vwap: false,
+  bollinger: false,
+  rsi: false,
+  macd: false,
+  sr: false,
+};
+
+export function useIndicatorPreferences(): [
+  IndicatorPreferences,
+  (key: keyof IndicatorPreferences) => void,
+] {
+  const [preferences, setPreferences] =
+    useState<IndicatorPreferences>(DEFAULT_PREFERENCES);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setPreferences({ ...DEFAULT_PREFERENCES, ...(JSON.parse(stored) as Partial<IndicatorPreferences>) });
+      } catch {
+        // ignore malformed stored data
+      }
+    }
+  }, []);
+
+  const toggle = (key: keyof IndicatorPreferences) => {
+    setPreferences((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  };
+
+  return [preferences, toggle];
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -1,0 +1,194 @@
+export interface OHLCVData {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function calcEMA(values: number[], period: number): (number | null)[] {
+  const result: (number | null)[] = new Array(values.length).fill(null);
+  if (values.length < period) return result;
+
+  const multiplier = 2 / (period + 1);
+  let ema = values.slice(0, period).reduce((sum, v) => sum + v, 0) / period;
+  result[period - 1] = ema;
+
+  for (let i = period; i < values.length; i++) {
+    ema = (values[i]! - ema) * multiplier + ema;
+    result[i] = ema;
+  }
+
+  return result;
+}
+
+export function calculateVWAP(
+  data: OHLCVData[],
+): { date: string; vwap: number }[] {
+  let cumTPV = 0;
+  let cumVol = 0;
+
+  return data.map((d) => {
+    const tp = (d.high + d.low + d.close) / 3;
+    cumTPV += tp * d.volume;
+    cumVol += d.volume;
+    return {
+      date: d.date,
+      vwap: cumVol > 0 ? cumTPV / cumVol : tp,
+    };
+  });
+}
+
+export function calculateBollingerBands(
+  data: OHLCVData[],
+  period = 20,
+  multiplier = 2,
+): {
+  date: string;
+  bbUpper: number | null;
+  bbMiddle: number | null;
+  bbLower: number | null;
+}[] {
+  const closes = data.map((d) => d.close);
+
+  return data.map((d, i) => {
+    if (i < period - 1)
+      return { date: d.date, bbUpper: null, bbMiddle: null, bbLower: null };
+
+    const slice = closes.slice(i - period + 1, i + 1);
+    const mean = slice.reduce((s, v) => s + v, 0) / period;
+    const variance =
+      slice.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / period;
+    const std = Math.sqrt(variance);
+
+    return {
+      date: d.date,
+      bbUpper: mean + multiplier * std,
+      bbMiddle: mean,
+      bbLower: mean - multiplier * std,
+    };
+  });
+}
+
+export function calculateRSI(
+  data: OHLCVData[],
+  period = 14,
+): { date: string; rsi: number | null }[] {
+  const closes = data.map((d) => d.close);
+  const result: { date: string; rsi: number | null }[] = data.map((d) => ({
+    date: d.date,
+    rsi: null,
+  }));
+
+  if (closes.length <= period) return result;
+
+  let avgGain = 0;
+  let avgLoss = 0;
+
+  for (let i = 1; i <= period; i++) {
+    const change = closes[i]! - closes[i - 1]!;
+    if (change > 0) avgGain += change;
+    else avgLoss -= change;
+  }
+  avgGain /= period;
+  avgLoss /= period;
+
+  const toRSI = (ag: number, al: number) =>
+    al === 0 ? 100 : 100 - 100 / (1 + ag / al);
+
+  result[period] = { date: data[period]!.date, rsi: toRSI(avgGain, avgLoss) };
+
+  for (let i = period + 1; i < closes.length; i++) {
+    const change = closes[i]! - closes[i - 1]!;
+    avgGain = (avgGain * (period - 1) + Math.max(change, 0)) / period;
+    avgLoss = (avgLoss * (period - 1) + Math.max(-change, 0)) / period;
+    result[i] = { date: data[i]!.date, rsi: toRSI(avgGain, avgLoss) };
+  }
+
+  return result;
+}
+
+export function calculateMACD(
+  data: OHLCVData[],
+  fastPeriod = 12,
+  slowPeriod = 26,
+  signalPeriod = 9,
+): {
+  date: string;
+  macdLine: number | null;
+  macdSignal: number | null;
+  macdHistogram: number | null;
+}[] {
+  const closes = data.map((d) => d.close);
+  const fastEMA = calcEMA(closes, fastPeriod);
+  const slowEMA = calcEMA(closes, slowPeriod);
+
+  const macdValues: (number | null)[] = closes.map((_, i) => {
+    const fast = fastEMA[i];
+    const slow = slowEMA[i];
+    return fast != null && slow != null ? fast - slow : null;
+  });
+
+  const firstValid = macdValues.findIndex((v) => v !== null);
+  const signalEMA: (number | null)[] = new Array(macdValues.length).fill(null);
+
+  if (firstValid !== -1 && macdValues.length - firstValid >= signalPeriod) {
+    const macdNonNull = macdValues.slice(firstValid) as number[];
+    const signalValues = calcEMA(macdNonNull, signalPeriod);
+    signalValues.forEach((v, i) => {
+      signalEMA[firstValid + i] = v;
+    });
+  }
+
+  return data.map((d, i) => ({
+    date: d.date,
+    macdLine: macdValues[i] ?? null,
+    macdSignal: signalEMA[i] ?? null,
+    macdHistogram:
+      macdValues[i] !== null && signalEMA[i] !== null
+        ? macdValues[i]! - signalEMA[i]!
+        : null,
+  }));
+}
+
+export function calculateSupportResistance(
+  data: OHLCVData[],
+  lookback = 5,
+): { date: string; type: "support" | "resistance"; level: number; strength: number }[] {
+  const result: {
+    date: string;
+    type: "support" | "resistance";
+    level: number;
+    strength: number;
+  }[] = [];
+
+  for (let i = lookback; i < data.length - lookback; i++) {
+    const d = data[i]!;
+
+    let isSwingHigh = true;
+    for (let j = i - lookback; j <= i + lookback; j++) {
+      if (j !== i && data[j]!.high >= d.high) {
+        isSwingHigh = false;
+        break;
+      }
+    }
+
+    let isSwingLow = true;
+    for (let j = i - lookback; j <= i + lookback; j++) {
+      if (j !== i && data[j]!.low <= d.low) {
+        isSwingLow = false;
+        break;
+      }
+    }
+
+    if (isSwingHigh) {
+      result.push({ date: d.date, type: "resistance", level: d.high, strength: 1 });
+    }
+    if (isSwingLow) {
+      result.push({ date: d.date, type: "support", level: d.low, strength: 1 });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Changes
Adds Convex tables and HTTP endpoints for thestockie-influencer Go job:

### New Tables
- `influencers` — tracked YouTube channels
- `influencerVideos` — video processing ledger
- `videoStockMentions` — per-video stock sentiments
- `macroNotes` — macro/sector commentary
- `dailySentiment` — aggregated consensus per ticker
- `macroDigest` — LLM-written daily synthesis
- `jobRuns` — execution observability

### HTTP Endpoints (under /influencer/*)
All guarded by Bearer auth (INGEST_SECRET):
- GET /active — list active influencers
- POST /seed — seed influencer list
- POST /video/discover — register new video
- POST /video/status — update processing status
- POST /video/result — save transcript + mentions
- POST /aggregate — recompute sentiment
- POST /digest — save daily macro digest
- POST /purge — clean old data
- POST /run/start, /run/finish — job tracking

### Read Queries
- `latestDigest`, `sentimentRanking`, `recentVideos`, `videosByChannel`, `latestRun`

## Testing
- Schema deployed to dev deployment (exciting-bee-603)
- INGEST_SECRET set via `npx convex env set`
- Go job successfully writes data via HTTP endpoints