### PR TITLE
feat: Super Investors — track 13F filings + cross-investor consensus

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,8 @@ import type * as http from "../http.js";
 import type * as influencer from "../influencer.js";
 import type * as influencerReads from "../influencerReads.js";
 import type * as posts from "../posts.js";
+import type * as superInvestor from "../superInvestor.js";
+import type * as superInvestorReads from "../superInvestorReads.js";
 
 import type {
   ApiFromModules,
@@ -26,6 +28,8 @@ declare const fullApi: ApiFromModules<{
   influencer: typeof influencer;
   influencerReads: typeof influencerReads;
   posts: typeof posts;
+  superInvestor: typeof superInvestor;
+  superInvestorReads: typeof superInvestorReads;
 }>;
 
 /**

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -193,4 +193,72 @@ http.route({
   ),
 });
 
+// ── Super investors (13F) ────────────────────────────────────────────────────
+
+http.route({
+  path: "/investor/active",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    if (!authorized(request)) return json({ error: "unauthorized" }, 401);
+    const result = await ctx.runQuery(internal.superInvestor.listActiveInvestors, {});
+    return json({ ok: true, result });
+  }),
+});
+
+http.route({
+  path: "/investor/seed",
+  method: "POST",
+  handler: endpoint((ctx, b) =>
+    ctx.runMutation(internal.superInvestor.upsertInvestor, {
+      name: b.name,
+      firm: b.firm,
+      style: b.style,
+      why: b.why,
+      cik: b.cik,
+      slug: b.slug,
+      avatar: b.avatar,
+      active: b.active,
+    })
+  ),
+});
+
+http.route({
+  path: "/investor/cusip/lookup",
+  method: "POST",
+  handler: endpoint((ctx, b) =>
+    ctx.runQuery(internal.superInvestor.cusipLookup, { cusips: b.cusips ?? [] })
+  ),
+});
+
+http.route({
+  path: "/investor/cusip/save",
+  method: "POST",
+  handler: endpoint((ctx, b) =>
+    ctx.runMutation(internal.superInvestor.cusipSave, { entries: b.entries ?? [] })
+  ),
+});
+
+http.route({
+  path: "/investor/filing",
+  method: "POST",
+  handler: endpoint((ctx, b) =>
+    ctx.runMutation(internal.superInvestor.saveFiling, {
+      cik: b.cik,
+      period: b.period,
+      reportDate: b.reportDate,
+      filingDate: b.filingDate,
+      totalValue: b.totalValue,
+      positions: b.positions ?? [],
+    })
+  ),
+});
+
+http.route({
+  path: "/investor/aggregate",
+  method: "POST",
+  handler: endpoint((ctx, b) =>
+    ctx.runMutation(internal.superInvestor.aggregateConsensus, { period: b.period })
+  ),
+});
+
 export default http;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -294,4 +294,96 @@ export default defineSchema({
     finishedAt: v.optional(v.number()),
     error: v.optional(v.string()),
   }).index("by_runAt", ["runAt"]),
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Super investors (SEC 13F) — populated by the superinvestor-job
+  // ───────────────────────────────────────────────────────────────────────────
+
+  superInvestors: defineTable({
+    name: v.string(),
+    firm: v.string(),
+    style: v.optional(v.string()),
+    why: v.optional(v.string()),
+    cik: v.string(),
+    slug: v.string(),
+    avatar: v.optional(v.string()),
+    active: v.boolean(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_cik", ["cik"])
+    .index("by_slug", ["slug"])
+    .index("by_active", ["active"]),
+
+  // One row per (investor, quarter) 13F filing.
+  investor13fFilings: defineTable({
+    investorId: v.id("superInvestors"),
+    cik: v.string(),
+    period: v.string(), // "2026-Q1"
+    reportDate: v.number(), // quarter-end, ms
+    filingDate: v.number(), // ms
+    totalValue: v.number(), // portfolio $ value
+    holdingsCount: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_investor", ["investorId"])
+    .index("by_period", ["period"])
+    .index("by_investor_period", ["investorId", "period"]),
+
+  // One row per (investor, quarter, holding) with the quarter-over-quarter move.
+  investorPositions: defineTable({
+    investorId: v.id("superInvestors"),
+    period: v.string(),
+    cusip: v.string(),
+    ticker: v.optional(v.string()),
+    name: v.string(), // issuer name
+    shares: v.number(),
+    value: v.number(), // $ value
+    pctPortfolio: v.number(), // 0..100
+    changeType: v.union(
+      v.literal("new"),
+      v.literal("added"),
+      v.literal("reduced"),
+      v.literal("sold"),
+      v.literal("hold")
+    ),
+    changePct: v.optional(v.number()), // share change %, signed
+    prevShares: v.optional(v.number()),
+    isOption: v.optional(v.boolean()),
+    createdAt: v.number(),
+  })
+    .index("by_investor_period", ["investorId", "period"])
+    .index("by_ticker", ["ticker"])
+    .index("by_period", ["period"]),
+
+  // Cross-investor consensus per ticker for a period.
+  investorConsensus: defineTable({
+    period: v.string(),
+    ticker: v.string(),
+    name: v.optional(v.string()),
+    buyers: v.number(), // # investors new/added
+    sellers: v.number(), // # investors reduced/sold
+    holders: v.number(), // # investors holding (any)
+    net: v.number(), // buyers - sellers
+    consensus: v.union(
+      v.literal("strong_buy"),
+      v.literal("buy"),
+      v.literal("mixed"),
+      v.literal("sell"),
+      v.literal("strong_sell")
+    ),
+    buyerNames: v.array(v.string()),
+    sellerNames: v.array(v.string()),
+    createdAt: v.number(),
+  })
+    .index("by_period", ["period"])
+    .index("by_period_ticker", ["period", "ticker"]),
+
+  // CUSIP→ticker cache (filled from OpenFIGI).
+  cusipTickers: defineTable({
+    cusip: v.string(),
+    ticker: v.optional(v.string()),
+    name: v.optional(v.string()),
+    createdAt: v.number(),
+  }).index("by_cusip", ["cusip"]),
 });

--- a/convex/superInvestor.ts
+++ b/convex/superInvestor.ts
@@ -1,0 +1,263 @@
+import { internalMutation, internalQuery } from "./_generated/server";
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+
+/**
+ * Internal queries & mutations for the super-investor (13F) feature, called by
+ * the external `superinvestor-job` via the HTTP endpoints in `http.ts`.
+ * Mirrors the influencer pipeline conventions.
+ */
+
+const changeTypeV = v.union(
+  v.literal("new"),
+  v.literal("added"),
+  v.literal("reduced"),
+  v.literal("sold"),
+  v.literal("hold")
+);
+
+// ── Investors ────────────────────────────────────────────────────────────────
+
+export const upsertInvestor = internalMutation({
+  args: {
+    name: v.string(),
+    firm: v.string(),
+    style: v.optional(v.string()),
+    why: v.optional(v.string()),
+    cik: v.string(),
+    slug: v.string(),
+    avatar: v.optional(v.string()),
+    active: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("superInvestors")
+      .withIndex("by_cik", (q) => q.eq("cik", args.cik))
+      .first();
+    const active = args.active ?? true;
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        name: args.name,
+        firm: args.firm,
+        style: args.style,
+        why: args.why,
+        slug: args.slug,
+        avatar: args.avatar,
+        active,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("superInvestors", { ...args, active, createdAt: now, updatedAt: now });
+  },
+});
+
+export const listActiveInvestors = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await ctx.db
+      .query("superInvestors")
+      .withIndex("by_active", (q) => q.eq("active", true))
+      .collect();
+    const out = [];
+    for (const i of rows) {
+      // Latest already-stored filing, so the job can skip when EDGAR has nothing newer.
+      const filings = await ctx.db
+        .query("investor13fFilings")
+        .withIndex("by_investor", (q) => q.eq("investorId", i._id))
+        .collect();
+      let lastFilingDate = 0;
+      let lastPeriod = "";
+      for (const f of filings) if (f.filingDate > lastFilingDate) { lastFilingDate = f.filingDate; lastPeriod = f.period; }
+      out.push({ id: i._id, cik: i.cik, name: i.name, slug: i.slug, lastFilingDate, lastPeriod });
+    }
+    return out;
+  },
+});
+
+// ── CUSIP→ticker cache ───────────────────────────────────────────────────────
+
+export const cusipLookup = internalQuery({
+  args: { cusips: v.array(v.string()) },
+  handler: async (ctx, { cusips }) => {
+    const out: Record<string, { ticker: string | null; name: string | null }> = {};
+    for (const c of cusips) {
+      const row = await ctx.db
+        .query("cusipTickers")
+        .withIndex("by_cusip", (q) => q.eq("cusip", c))
+        .first();
+      if (row) out[c] = { ticker: row.ticker ?? null, name: row.name ?? null };
+    }
+    return out;
+  },
+});
+
+export const cusipSave = internalMutation({
+  args: {
+    entries: v.array(
+      v.object({
+        cusip: v.string(),
+        ticker: v.optional(v.string()),
+        name: v.optional(v.string()),
+      })
+    ),
+  },
+  handler: async (ctx, { entries }) => {
+    const now = Date.now();
+    for (const e of entries) {
+      const existing = await ctx.db
+        .query("cusipTickers")
+        .withIndex("by_cusip", (q) => q.eq("cusip", e.cusip))
+        .first();
+      if (existing) await ctx.db.patch(existing._id, { ticker: e.ticker, name: e.name });
+      else await ctx.db.insert("cusipTickers", { cusip: e.cusip, ticker: e.ticker, name: e.name, createdAt: now });
+    }
+  },
+});
+
+// ── Filings + positions ──────────────────────────────────────────────────────
+
+export const saveFiling = internalMutation({
+  args: {
+    cik: v.string(),
+    period: v.string(),
+    reportDate: v.number(),
+    filingDate: v.number(),
+    totalValue: v.number(),
+    positions: v.array(
+      v.object({
+        cusip: v.string(),
+        ticker: v.optional(v.string()),
+        name: v.string(),
+        shares: v.number(),
+        value: v.number(),
+        pctPortfolio: v.number(),
+        changeType: changeTypeV,
+        changePct: v.optional(v.number()),
+        prevShares: v.optional(v.number()),
+        isOption: v.optional(v.boolean()),
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    const inv = await ctx.db
+      .query("superInvestors")
+      .withIndex("by_cik", (q) => q.eq("cik", args.cik))
+      .first();
+    if (!inv) throw new Error(`unknown investor cik ${args.cik}`);
+
+    // Replace any existing filing + positions for this (investor, period).
+    const oldF = await ctx.db
+      .query("investor13fFilings")
+      .withIndex("by_investor_period", (q) => q.eq("investorId", inv._id).eq("period", args.period))
+      .collect();
+    for (const f of oldF) await ctx.db.delete(f._id);
+    const oldP = await ctx.db
+      .query("investorPositions")
+      .withIndex("by_investor_period", (q) => q.eq("investorId", inv._id).eq("period", args.period))
+      .collect();
+    for (const p of oldP) await ctx.db.delete(p._id);
+
+    const now = Date.now();
+    await ctx.db.insert("investor13fFilings", {
+      investorId: inv._id,
+      cik: args.cik,
+      period: args.period,
+      reportDate: args.reportDate,
+      filingDate: args.filingDate,
+      totalValue: args.totalValue,
+      holdingsCount: args.positions.length,
+      createdAt: now,
+    });
+    for (const p of args.positions) {
+      await ctx.db.insert("investorPositions", { investorId: inv._id, period: args.period, ...p, createdAt: now });
+    }
+    return { positions: args.positions.length };
+  },
+});
+
+// ── Cross-investor consensus ─────────────────────────────────────────────────
+
+type Consensus =
+  | "strong_buy"
+  | "buy"
+  | "mixed"
+  | "sell"
+  | "strong_sell";
+
+function consensusLabel(buy: number, sell: number): Consensus {
+  const total = buy + sell;
+  if (total === 0) return "mixed";
+  const ratio = (buy - sell) / total;
+  if (ratio >= 0.6 && buy >= 2) return "strong_buy";
+  if (ratio <= -0.6 && sell >= 2) return "strong_sell";
+  if (ratio > 0.15) return "buy";
+  if (ratio < -0.15) return "sell";
+  return "mixed";
+}
+
+export const aggregateConsensus = internalMutation({
+  args: { period: v.string() },
+  handler: async (ctx, { period }) => {
+    const positions = await ctx.db
+      .query("investorPositions")
+      .withIndex("by_period", (q) => q.eq("period", period))
+      .collect();
+
+    const nameCache = new Map<string, string>();
+    const nameOf = async (id: Id<"superInvestors">) => {
+      let n = nameCache.get(id as string);
+      if (n === undefined) {
+        const inv = await ctx.db.get(id);
+        n = inv?.name ?? "Unknown";
+        nameCache.set(id as string, n);
+      }
+      return n;
+    };
+
+    type Agg = { ticker: string; name?: string; buyers: Set<string>; sellers: Set<string>; holders: Set<string> };
+    const byTicker = new Map<string, Agg>();
+    for (const p of positions) {
+      if (!p.ticker) continue; // consensus board is ticker-keyed
+      let a = byTicker.get(p.ticker);
+      if (!a) {
+        a = { ticker: p.ticker, name: p.name, buyers: new Set(), sellers: new Set(), holders: new Set() };
+        byTicker.set(p.ticker, a);
+      }
+      const iname = await nameOf(p.investorId);
+      a.holders.add(iname);
+      if (p.changeType === "new" || p.changeType === "added") a.buyers.add(iname);
+      else if (p.changeType === "reduced" || p.changeType === "sold") a.sellers.add(iname);
+    }
+
+    const old = await ctx.db
+      .query("investorConsensus")
+      .withIndex("by_period", (q) => q.eq("period", period))
+      .collect();
+    for (const r of old) await ctx.db.delete(r._id);
+
+    const now = Date.now();
+    let stored = 0;
+    for (const a of byTicker.values()) {
+      const buy = a.buyers.size;
+      const sell = a.sellers.size;
+      if (buy === 0 && sell === 0) continue; // no moves this quarter
+      await ctx.db.insert("investorConsensus", {
+        period,
+        ticker: a.ticker,
+        name: a.name,
+        buyers: buy,
+        sellers: sell,
+        holders: a.holders.size,
+        net: buy - sell,
+        consensus: consensusLabel(buy, sell),
+        buyerNames: [...a.buyers],
+        sellerNames: [...a.sellers],
+        createdAt: now,
+      });
+      stored++;
+    }
+    return { tickers: stored };
+  },
+});

--- a/convex/superInvestorReads.ts
+++ b/convex/superInvestorReads.ts
@@ -1,0 +1,202 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { QueryCtx } from "./_generated/server";
+
+/** Public read queries for the super-investor feature (consumed by tRPC). */
+
+async function latestFilingPeriod(ctx: QueryCtx): Promise<string | null> {
+  const f = await ctx.db.query("investor13fFilings").withIndex("by_period").order("desc").first();
+  return f?.period ?? null;
+}
+
+async function investorNamer(ctx: QueryCtx) {
+  const cache = new Map<string, { name: string; slug: string }>();
+  return async (id: Id<"superInvestors">) => {
+    let v = cache.get(id as string);
+    if (!v) {
+      const inv = await ctx.db.get(id);
+      v = { name: inv?.name ?? "Unknown", slug: inv?.slug ?? "" };
+      cache.set(id as string, v);
+    }
+    return v;
+  };
+}
+
+// Roster of investors with their latest-quarter move summary.
+export const investors = query({
+  args: {},
+  handler: async (ctx) => {
+    const list = await ctx.db
+      .query("superInvestors")
+      .withIndex("by_active", (q) => q.eq("active", true))
+      .collect();
+    const out = [];
+    for (const inv of list) {
+      const filings = await ctx.db
+        .query("investor13fFilings")
+        .withIndex("by_investor", (q) => q.eq("investorId", inv._id))
+        .collect();
+      filings.sort((a, b) => b.period.localeCompare(a.period));
+      const latest = filings[0] ?? null;
+      const moves = { new: 0, added: 0, reduced: 0, sold: 0 };
+      if (latest) {
+        const pos = await ctx.db
+          .query("investorPositions")
+          .withIndex("by_investor_period", (q) => q.eq("investorId", inv._id).eq("period", latest.period))
+          .collect();
+        for (const p of pos) if (p.changeType in moves) moves[p.changeType as keyof typeof moves]++;
+      }
+      out.push({
+        _id: inv._id,
+        name: inv.name,
+        firm: inv.firm,
+        style: inv.style ?? null,
+        why: inv.why ?? null,
+        slug: inv.slug,
+        avatar: inv.avatar ?? null,
+        period: latest?.period ?? null,
+        totalValue: latest?.totalValue ?? null,
+        holdingsCount: latest?.holdingsCount ?? 0,
+        moves,
+      });
+    }
+    out.sort((a, b) => (b.totalValue ?? 0) - (a.totalValue ?? 0));
+    return out;
+  },
+});
+
+// "Most bought / Most sold" consensus leaderboard — same net-leaning + >2 + fill
+// rules as the influencer sentiment board.
+export const consensus = query({
+  args: { period: v.optional(v.string()), limit: v.optional(v.number()) },
+  handler: async (ctx, { period, limit }) => {
+    const theP = period ?? (await latestFilingPeriod(ctx));
+    if (!theP) return { period: null, bought: [], sold: [] };
+    const rows = await ctx.db
+      .query("investorConsensus")
+      .withIndex("by_period", (q) => q.eq("period", theP))
+      .collect();
+    const n = limit ?? 12;
+    type R = (typeof rows)[number];
+    const pick = (mine: (r: R) => number, theirs: (r: R) => number) => {
+      const ranked = rows
+        .filter((r) => mine(r) > theirs(r))
+        .sort(
+          (a, b) =>
+            mine(b) - mine(a) || mine(b) - theirs(b) - (mine(a) - theirs(a)) || b.holders - a.holders
+        );
+      const strong = ranked.filter((r) => mine(r) > 2);
+      return strong.length >= n ? strong : ranked.slice(0, n);
+    };
+    return {
+      period: theP,
+      bought: pick(
+        (r) => r.buyers,
+        (r) => r.sellers
+      ),
+      sold: pick(
+        (r) => r.sellers,
+        (r) => r.buyers
+      ),
+    };
+  },
+});
+
+// Biggest individual moves this quarter (new buys, full exits, adds, trims).
+export const notableMoves = query({
+  args: { period: v.optional(v.string()), limit: v.optional(v.number()) },
+  handler: async (ctx, { period, limit }) => {
+    const theP = period ?? (await latestFilingPeriod(ctx));
+    if (!theP) return { period: null, newBuys: [], exits: [], adds: [], trims: [] };
+    const pos = await ctx.db
+      .query("investorPositions")
+      .withIndex("by_period", (q) => q.eq("period", theP))
+      .collect();
+    const namer = await investorNamer(ctx);
+    const n = limit ?? 8;
+    const enrich = async (p: Doc<"investorPositions">) => {
+      const who = await namer(p.investorId);
+      return {
+        ticker: p.ticker ?? null,
+        name: p.name,
+        investor: who.name,
+        slug: who.slug,
+        value: p.value,
+        pctPortfolio: p.pctPortfolio,
+        changePct: p.changePct ?? null,
+      };
+    };
+    const top = async (type: string, sortVal: (p: Doc<"investorPositions">) => number) => {
+      const rows = pos.filter((p) => p.changeType === type).sort((a, b) => sortVal(b) - sortVal(a)).slice(0, n);
+      return Promise.all(rows.map(enrich));
+    };
+    return {
+      period: theP,
+      newBuys: await top("new", (p) => p.value),
+      exits: await top("sold", (p) => p.value), // value = prior stake size for exits
+      adds: await top("added", (p) => p.value),
+      trims: await top("reduced", (p) => Math.abs(p.changePct ?? 0)),
+    };
+  },
+});
+
+// One investor's latest 13F: holdings + moves, with period switching.
+export const investorBySlug = query({
+  args: { slug: v.string(), period: v.optional(v.string()) },
+  handler: async (ctx, { slug, period }) => {
+    const inv = await ctx.db
+      .query("superInvestors")
+      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .first();
+    if (!inv) return null;
+    const filings = await ctx.db
+      .query("investor13fFilings")
+      .withIndex("by_investor", (q) => q.eq("investorId", inv._id))
+      .collect();
+    filings.sort((a, b) => b.period.localeCompare(a.period));
+    const theP = period ?? filings[0]?.period ?? null;
+    const filing = filings.find((f) => f.period === theP) ?? null;
+    let positions: Doc<"investorPositions">[] = [];
+    if (theP) {
+      positions = await ctx.db
+        .query("investorPositions")
+        .withIndex("by_investor_period", (q) => q.eq("investorId", inv._id).eq("period", theP))
+        .collect();
+    }
+    return {
+      investor: {
+        name: inv.name,
+        firm: inv.firm,
+        style: inv.style ?? null,
+        why: inv.why ?? null,
+        slug: inv.slug,
+        avatar: inv.avatar ?? null,
+        cik: inv.cik,
+      },
+      period: theP,
+      periods: filings.map((f) => f.period),
+      filing: filing
+        ? {
+            filingDate: filing.filingDate,
+            reportDate: filing.reportDate,
+            totalValue: filing.totalValue,
+            holdingsCount: filing.holdingsCount,
+          }
+        : null,
+      positions: positions
+        .map((p) => ({
+          ticker: p.ticker ?? null,
+          name: p.name,
+          shares: p.shares,
+          value: p.value,
+          pctPortfolio: p.pctPortfolio,
+          changeType: p.changeType,
+          changePct: p.changePct ?? null,
+          prevShares: p.prevShares ?? null,
+          isOption: p.isOption ?? false,
+        }))
+        .sort((a, b) => b.value - a.value),
+    };
+  },
+});

--- a/src/app/influencers/page.tsx
+++ b/src/app/influencers/page.tsx
@@ -8,6 +8,7 @@ import { InfluencerDigest } from "~/components/features/influencer-digest";
 import { SentimentLeaderboard } from "~/components/features/influencer-sentiment";
 import { InfluencerRoster } from "~/components/features/influencer-roster";
 import { RecentInfluencerVideos } from "~/components/features/influencer-videos";
+import { SuperInvestorsSection } from "~/components/features/super-investor-section";
 import { formatRelative } from "~/components/features/influencer-shared";
 
 function LoadingState() {
@@ -105,6 +106,8 @@ export default function InfluencersPage() {
             </div>
           </div>
         )}
+
+        <SuperInvestorsSection />
       </div>
     </div>
   );

--- a/src/app/investors/[slug]/page.tsx
+++ b/src/app/investors/[slug]/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { api } from "~/trpc/react";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Skeleton } from "~/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import {
+  MoveBadge,
+  moveColor,
+  formatMoney,
+  formatPct,
+} from "~/components/features/super-investor-shared";
+
+function initials(name: string): string {
+  return name
+    .split(" ")
+    .map((p) => p[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+function periodLabel(p: string | null): string {
+  if (!p) return "—";
+  const [y, q] = p.split("-");
+  return `${q} ${y}`;
+}
+
+export default function InvestorDetailPage() {
+  const params = useParams();
+  const slug = String(params?.slug ?? "");
+  const { data, isLoading } = api.superInvestor.bySlug.useQuery(
+    { slug },
+    { enabled: !!slug },
+  );
+
+  return (
+    <div className="min-h-screen bg-[#15162c] pb-20 text-white">
+      <div className="mx-auto max-w-5xl px-4 pt-6">
+        <Link
+          href="/influencers"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to Influencer Radar
+        </Link>
+
+        {isLoading ? (
+          <Skeleton className="h-96 w-full rounded-xl bg-white/5" />
+        ) : !data ? (
+          <p className="py-16 text-center text-gray-400">Investor not found.</p>
+        ) : (
+          <>
+            <Card className="mb-4 border-white/10 bg-white/5 text-white">
+              <CardHeader className="flex flex-row items-start gap-4 space-y-0">
+                <Avatar className="h-14 w-14 shrink-0">
+                  {data.investor.avatar && (
+                    <AvatarImage src={data.investor.avatar} alt={data.investor.name} />
+                  )}
+                  <AvatarFallback className="bg-purple-500/20 text-purple-200">
+                    {initials(data.investor.name)}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <h1 className="text-2xl font-bold">{data.investor.name}</h1>
+                  <p className="text-sm text-gray-400">
+                    {data.investor.firm}
+                    {data.investor.style ? ` · ${data.investor.style}` : ""}
+                  </p>
+                  {data.investor.why && (
+                    <p className="mt-2 max-w-2xl text-sm text-gray-300">{data.investor.why}</p>
+                  )}
+                </div>
+                {data.filing && (
+                  <div className="shrink-0 text-right text-sm">
+                    <div className="font-semibold">{formatMoney(data.filing.totalValue)}</div>
+                    <div className="text-xs text-gray-400">{data.filing.holdingsCount} holdings</div>
+                    <div className="mt-1 text-xs text-gray-500">
+                      {periodLabel(data.period)} · filed{" "}
+                      {new Date(data.filing.filingDate).toLocaleDateString()}
+                    </div>
+                  </div>
+                )}
+              </CardHeader>
+            </Card>
+
+            <Card className="border-white/10 bg-white/5 text-white">
+              <CardHeader className="pb-2">
+                <h2 className="text-sm font-semibold">Holdings &amp; moves</h2>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-white/10 hover:bg-transparent">
+                      <TableHead className="text-gray-400">Ticker</TableHead>
+                      <TableHead className="text-gray-400">Company</TableHead>
+                      <TableHead className="text-gray-400">Move</TableHead>
+                      <TableHead className="text-right text-gray-400">% Book</TableHead>
+                      <TableHead className="text-right text-gray-400">Value</TableHead>
+                      <TableHead className="text-right text-gray-400">Δ Shares</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {data.positions.map((p, i) => (
+                      <TableRow key={`${p.ticker ?? p.name}-${i}`} className="border-white/5">
+                        <TableCell className="font-semibold">
+                          {p.ticker ? (
+                            <Link href={`/?symbol=${p.ticker}`} className="text-white hover:underline">
+                              {p.ticker}
+                            </Link>
+                          ) : (
+                            <span className="text-gray-500">—</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="max-w-[220px] truncate text-gray-300">
+                          {p.name}
+                          {p.isOption && <span className="ml-1 text-[10px] text-amber-400">OPT</span>}
+                        </TableCell>
+                        <TableCell>
+                          <MoveBadge type={p.changeType} />
+                        </TableCell>
+                        <TableCell className="text-right text-gray-300">
+                          {p.changeType === "sold" ? "—" : `${p.pctPortfolio.toFixed(1)}%`}
+                        </TableCell>
+                        <TableCell className="text-right text-gray-300">
+                          {p.changeType === "sold" ? "exited" : formatMoney(p.value)}
+                        </TableCell>
+                        <TableCell className={`text-right ${moveColor(p.changeType)}`}>
+                          {p.changeType === "new"
+                            ? "new"
+                            : p.changeType === "sold"
+                              ? "−100%"
+                              : formatPct(p.changePct)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/navbar.tsx
+++ b/src/components/features/navbar.tsx
@@ -44,6 +44,7 @@ const PAGE_TITLES: Record<string, string> = {
   "/blogs": "Blog",
   "/screener": "Screener",
   "/influencers": "Influencer Radar",
+  "/investors": "Super Investors",
   "/earnings": "Earnings Calendar",
   "/compare": "Stock Comparison",
   "/macro": "Macro Overview",

--- a/src/components/features/super-investor-consensus.tsx
+++ b/src/components/features/super-investor-consensus.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { type ReactNode } from "react";
+import Link from "next/link";
+import { ShoppingCart, TrendingDown } from "lucide-react";
+import { type RouterOutputs } from "~/trpc/react";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { InvestorConsensusBadge } from "./super-investor-shared";
+
+type Consensus = RouterOutputs["superInvestor"]["consensus"];
+type Row = Consensus["bought"][number];
+
+function InvestorCount({
+  count,
+  arrow,
+  color,
+  names,
+}: {
+  count: number;
+  arrow: string;
+  color: string;
+  names: string[];
+}) {
+  if (names.length === 0) {
+    return (
+      <span className={color}>
+        {count}
+        {arrow}
+      </span>
+    );
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={`cursor-help ${color}`}>
+          {count}
+          {arrow}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="left" className="max-w-[260px]">
+        <ul className="space-y-0.5 text-xs leading-snug">
+          {names.map((n) => (
+            <li key={n}>{n}</li>
+          ))}
+        </ul>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function SymbolRow({ row, rank }: { row: Row; rank: number }) {
+  return (
+    <div className="flex items-center gap-3 rounded-md bg-black/20 px-3 py-2">
+      <span className="w-4 shrink-0 text-right text-xs text-gray-500">{rank}</span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/?symbol=${row.ticker}`}
+            className="font-semibold text-white hover:underline"
+          >
+            {row.ticker}
+          </Link>
+          <InvestorConsensusBadge consensus={row.consensus} />
+        </div>
+        {row.name && <p className="truncate text-xs text-gray-500">{row.name}</p>}
+      </div>
+      <div className="shrink-0 text-right text-sm">
+        <InvestorCount count={row.buyers} arrow="↑" color="text-emerald-400" names={row.buyerNames} />{" "}
+        <InvestorCount count={row.sellers} arrow="↓" color="text-rose-400" names={row.sellerNames} />
+      </div>
+    </div>
+  );
+}
+
+function Side({
+  title,
+  icon,
+  accent,
+  rows,
+  empty,
+}: {
+  title: string;
+  icon: ReactNode;
+  accent: string;
+  rows: Row[];
+  empty: string;
+}) {
+  return (
+    <Card className="border-white/10 bg-white/5 text-white">
+      <CardHeader className="space-y-0 pb-3">
+        <div className={`flex items-center gap-2 text-sm font-semibold ${accent}`}>
+          {icon} {title}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1.5">
+        {rows.length === 0 ? (
+          <p className="py-6 text-center text-sm text-gray-500">{empty}</p>
+        ) : (
+          rows.map((row, i) => <SymbolRow key={row.ticker} row={row} rank={i + 1} />)
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function InvestorConsensus({ consensus }: { consensus: Consensus }) {
+  return (
+    <TooltipProvider delayDuration={100}>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Side
+          title="Most bought"
+          icon={<ShoppingCart className="h-4 w-4" />}
+          accent="text-emerald-400"
+          rows={consensus.bought}
+          empty="No multi-investor buying this quarter."
+        />
+        <Side
+          title="Most sold"
+          icon={<TrendingDown className="h-4 w-4" />}
+          accent="text-rose-400"
+          rows={consensus.sold}
+          empty="No multi-investor selling this quarter."
+        />
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/features/super-investor-moves.tsx
+++ b/src/components/features/super-investor-moves.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { type ReactNode } from "react";
+import Link from "next/link";
+import { Sparkles, DoorOpen } from "lucide-react";
+import { type RouterOutputs } from "~/trpc/react";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { formatMoney } from "./super-investor-shared";
+
+type Moves = RouterOutputs["superInvestor"]["notableMoves"];
+type Move = Moves["newBuys"][number];
+
+function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md bg-black/20 px-3 py-2 text-sm">
+      <div className="min-w-0">
+        <Link href={`/investors/${m.slug}`} className="text-xs text-purple-200 hover:underline">
+          {m.investor}
+        </Link>
+        <div className="flex items-center gap-2">
+          {m.ticker ? (
+            <Link href={`/?symbol=${m.ticker}`} className="font-semibold text-white hover:underline">
+              {m.ticker}
+            </Link>
+          ) : (
+            <span className="font-medium text-gray-400">—</span>
+          )}
+          <span className="truncate text-xs text-gray-500">{m.name}</span>
+        </div>
+      </div>
+      <div className="shrink-0 text-right">
+        <div className={kind === "buy" ? "text-emerald-400" : "text-rose-400"}>
+          {formatMoney(m.value)}
+        </div>
+        {kind === "buy" && m.pctPortfolio > 0 && (
+          <div className="text-[11px] text-gray-500">{Math.round(m.pctPortfolio)}% of book</div>
+        )}
+        {kind === "sell" && <div className="text-[11px] text-gray-500">exited</div>}
+      </div>
+    </div>
+  );
+}
+
+function MoveCard({
+  title,
+  icon,
+  accent,
+  rows,
+  empty,
+  kind,
+}: {
+  title: string;
+  icon: ReactNode;
+  accent: string;
+  rows: Move[];
+  empty: string;
+  kind: "buy" | "sell";
+}) {
+  return (
+    <Card className="border-white/10 bg-white/5 text-white">
+      <CardHeader className="space-y-0 pb-3">
+        <div className={`flex items-center gap-2 text-sm font-semibold ${accent}`}>
+          {icon} {title}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1.5">
+        {rows.length === 0 ? (
+          <p className="py-6 text-center text-sm text-gray-500">{empty}</p>
+        ) : (
+          rows.map((m, i) => <MoveRow key={`${m.slug}-${m.ticker ?? m.name}-${i}`} m={m} kind={kind} />)
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function InvestorMoves({ moves }: { moves: Moves }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <MoveCard
+        title="Biggest new buys"
+        icon={<Sparkles className="h-4 w-4" />}
+        accent="text-emerald-400"
+        rows={moves.newBuys}
+        empty="No new positions this quarter."
+        kind="buy"
+      />
+      <MoveCard
+        title="Full exits"
+        icon={<DoorOpen className="h-4 w-4" />}
+        accent="text-rose-400"
+        rows={moves.exits}
+        empty="No full exits this quarter."
+        kind="sell"
+      />
+    </div>
+  );
+}

--- a/src/components/features/super-investor-roster.tsx
+++ b/src/components/features/super-investor-roster.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { type RouterOutputs } from "~/trpc/react";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { formatMoney } from "./super-investor-shared";
+
+type Investor = RouterOutputs["superInvestor"]["investors"][number];
+
+function initials(name: string): string {
+  return name
+    .split(" ")
+    .map((p) => p[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+function InvestorCard({ inv }: { inv: Investor }) {
+  return (
+    <Link
+      href={`/investors/${inv.slug}`}
+      className="group block rounded-lg border border-white/10 bg-black/20 p-3 transition-colors hover:bg-white/5"
+    >
+      <div className="flex items-center gap-3">
+        <Avatar className="h-10 w-10 shrink-0">
+          {inv.avatar && <AvatarImage src={inv.avatar} alt={inv.name} />}
+          <AvatarFallback className="bg-purple-500/20 text-xs text-purple-200">
+            {initials(inv.name)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-white group-hover:underline">{inv.name}</div>
+          <div className="truncate text-xs text-gray-500">{inv.firm}</div>
+        </div>
+        {inv.totalValue != null && (
+          <div className="shrink-0 text-right text-xs text-gray-400">
+            {formatMoney(inv.totalValue)}
+            <div className="text-gray-600">{inv.holdingsCount} pos</div>
+          </div>
+        )}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-2 gap-y-0.5 text-[11px]">
+        {inv.moves.new > 0 && <span className="text-emerald-400">{inv.moves.new} new</span>}
+        {inv.moves.added > 0 && <span className="text-emerald-300">{inv.moves.added} added</span>}
+        {inv.moves.reduced > 0 && <span className="text-amber-300">{inv.moves.reduced} trimmed</span>}
+        {inv.moves.sold > 0 && <span className="text-rose-400">{inv.moves.sold} exited</span>}
+        {inv.period === null && <span className="text-gray-600">no filing yet</span>}
+      </div>
+    </Link>
+  );
+}
+
+export function InvestorRoster({ investors }: { investors: Investor[] }) {
+  return (
+    <Card className="border-white/10 bg-white/5 text-white">
+      <CardHeader className="pb-3">
+        <h3 className="text-sm font-semibold">Tracked investors ({investors.length})</h3>
+      </CardHeader>
+      <CardContent className="grid gap-2 sm:grid-cols-2">
+        {investors.map((inv) => (
+          <InvestorCard key={inv._id} inv={inv} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/features/super-investor-section.tsx
+++ b/src/components/features/super-investor-section.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Landmark } from "lucide-react";
+import { api } from "~/trpc/react";
+import { Skeleton } from "~/components/ui/skeleton";
+import { Card, CardContent } from "~/components/ui/card";
+import { InvestorMoves } from "./super-investor-moves";
+import { InvestorConsensus } from "./super-investor-consensus";
+import { InvestorRoster } from "./super-investor-roster";
+
+function periodLabel(p: string | null): string {
+  if (!p) return "";
+  const [y, q] = p.split("-");
+  return `${q} ${y}`;
+}
+
+export function SuperInvestorsSection() {
+  const consensusQ = api.superInvestor.consensus.useQuery({ limit: 12 });
+  const movesQ = api.superInvestor.notableMoves.useQuery({ limit: 8 });
+  const investorsQ = api.superInvestor.investors.useQuery();
+
+  const loading = consensusQ.isLoading || movesQ.isLoading || investorsQ.isLoading;
+  const period = consensusQ.data?.period ?? movesQ.data?.period ?? null;
+  const hasData = (investorsQ.data?.length ?? 0) > 0;
+
+  return (
+    <section className="mt-12 border-t border-white/10 pt-8">
+      <div className="mb-1 flex items-center gap-2">
+        <Landmark className="h-6 w-6 text-amber-400" />
+        <h2 className="text-2xl font-bold">Super Investors</h2>
+        {period && (
+          <span className="rounded-md bg-white/5 px-2 py-0.5 text-xs text-gray-400">
+            13F · {periodLabel(period)}
+          </span>
+        )}
+      </div>
+      <p className="mb-4 max-w-3xl text-sm text-gray-400">
+        How legendary fund managers moved their books, from quarterly SEC 13F filings.{" "}
+        <span className="text-gray-500">
+          13F covers long US positions only and lags ~45 days, so a sale means trimmed or
+          exited — not short.
+        </span>
+      </p>
+
+      {loading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-56 w-full rounded-xl bg-white/5" />
+          <Skeleton className="h-56 w-full rounded-xl bg-white/5" />
+        </div>
+      ) : !hasData ? (
+        <Card className="border-white/10 bg-white/5 text-white">
+          <CardContent className="py-12 text-center text-sm text-gray-400">
+            No 13F data yet — run the superinvestor-job.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {movesQ.data && <InvestorMoves moves={movesQ.data} />}
+          {consensusQ.data && <InvestorConsensus consensus={consensusQ.data} />}
+          {investorsQ.data && <InvestorRoster investors={investorsQ.data} />}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/features/super-investor-shared.tsx
+++ b/src/components/features/super-investor-shared.tsx
@@ -1,0 +1,56 @@
+import { Pill } from "./influencer-shared";
+
+const CONSENSUS: Record<string, string> = {
+  strong_buy: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
+  buy: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/25",
+  mixed: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
+  sell: "bg-rose-500/10 text-rose-300 ring-rose-500/25",
+  strong_sell: "bg-rose-500/20 text-rose-200 ring-rose-500/40",
+};
+
+export function InvestorConsensusBadge({ consensus }: { consensus: string }) {
+  return (
+    <Pill className={CONSENSUS[consensus] ?? CONSENSUS.mixed}>
+      {consensus.replace("_", " ")}
+    </Pill>
+  );
+}
+
+const MOVE_LABEL: Record<string, string> = {
+  new: "new",
+  added: "added",
+  reduced: "trimmed",
+  sold: "sold out",
+  hold: "hold",
+};
+const MOVE_STYLE: Record<string, string> = {
+  new: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
+  added: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/25",
+  reduced: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
+  sold: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
+  hold: "bg-slate-500/15 text-slate-300 ring-slate-500/30",
+};
+
+export function MoveBadge({ type }: { type: string }) {
+  return <Pill className={MOVE_STYLE[type] ?? MOVE_STYLE.hold}>{MOVE_LABEL[type] ?? type}</Pill>;
+}
+
+export function moveColor(type: string): string {
+  if (type === "new" || type === "added") return "text-emerald-400";
+  if (type === "reduced" || type === "sold") return "text-rose-400";
+  return "text-slate-400";
+}
+
+export function formatMoney(v: number): string {
+  if (v >= 1e12) return `$${(v / 1e12).toFixed(1)}T`;
+  if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `$${(v / 1e6).toFixed(0)}M`;
+  if (v >= 1e3) return `$${(v / 1e3).toFixed(0)}K`;
+  return `$${Math.round(v)}`;
+}
+
+export function formatPct(v: number | null | undefined): string {
+  if (v === null || v === undefined) return "—";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${Math.round(v)}%`;
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,6 +2,7 @@ import { postRouter } from "~/server/api/routers/post";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { assetsRouter } from "./routers/assets";
 import { influencerRouter } from "./routers/influencer";
+import { superInvestorRouter } from "./routers/superInvestor";
 
 /**
  * This is the primary router for your server.
@@ -12,6 +13,7 @@ export const appRouter = createTRPCRouter({
   post: postRouter,
   asset: assetsRouter,
   influencer: influencerRouter,
+  superInvestor: superInvestorRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/superInvestor.ts
+++ b/src/server/api/routers/superInvestor.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { api } from "../../../../convex/_generated/api";
+
+/**
+ * Read-only API for the super-investor (13F) feature. Data is produced by the
+ * external `superinvestor-job` and stored in Convex.
+ */
+export const superInvestorRouter = createTRPCRouter({
+  investors: publicProcedure.query(async ({ ctx }) => {
+    return await ctx.convex.query(api.superInvestorReads.investors, {});
+  }),
+
+  consensus: publicProcedure
+    .input(
+      z
+        .object({
+          period: z.string().optional(),
+          limit: z.number().min(1).max(50).optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      return await ctx.convex.query(api.superInvestorReads.consensus, {
+        period: input?.period,
+        limit: input?.limit,
+      });
+    }),
+
+  notableMoves: publicProcedure
+    .input(
+      z
+        .object({
+          period: z.string().optional(),
+          limit: z.number().min(1).max(20).optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      return await ctx.convex.query(api.superInvestorReads.notableMoves, {
+        period: input?.period,
+        limit: input?.limit,
+      });
+    }),
+
+  bySlug: publicProcedure
+    .input(z.object({ slug: z.string(), period: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      return (
+        (await ctx.convex.query(api.superInvestorReads.investorBySlug, {
+          slug: input.slug,
+          period: input.period,
+        })) ?? null
+      );
+    }),
+});


### PR DESCRIPTION
Adds a **Super Investors** section to `/influencers` (header-separated from the YouTube creators) plus a per-investor detail page, sourced from quarterly **SEC 13F** filings of 10 legendary fund managers.

## What it shows
- **Notable moves** — biggest new buys and full exits this quarter.
- **Consensus board** — Most bought / Most sold by # of investors (reuses the influencer leaderboard rules + creator-name tooltips). e.g. Q1'26: most bought **AVGO** (3 investors), most sold **UNH/NVDA/MSFT** (3 each).
- **Roster** — the 10 investors with their move summary, linking to **/investors/[slug]** (full holdings + new/added/trimmed/exited).

## Backend (Convex)
`superInvestors`, `investor13fFilings`, `investorPositions`, `investorConsensus`, `cusipTickers` + mutations, consensus aggregation, bearer-guarded `/investor/*` ingest endpoints, and read queries. Producer is the **superinvestor-job** (separate repo: SEC EDGAR → QoQ diff → OpenFIGI tickers).

## Notes
- 13F is **long-only** and lags ~45 days — surfaced in the UI ("as of Qx, filed …"; "sold" = trimmed/exited, not short).
- Based on `feat/influencer-radar` (PR #25) since it shares schema/http/nav; data already loaded for **2026-Q1**.
- `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)