### PR TITLE
fix: add missing investorBySlug query and optional params

### DIFF
--- a/convex/influencerReads.ts
+++ b/convex/influencerReads.ts
@@ -30,17 +30,33 @@ export const latestDigest = query({
 });
 
 export const sentimentRanking = query({
-  handler: async (ctx) => {
+  args: {
+    date: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
     const sentiments = await ctx.db.query("dailySentiment").collect();
-    const bullish = sentiments
+    
+    // Filter by date if provided
+    let filtered = sentiments;
+    if (args.date) {
+      filtered = sentiments.filter((s) => s.date === args.date);
+    }
+    
+    const bullish = filtered
       .filter((s) => s.consensus === "strong_bullish" || s.consensus === "bullish")
-      .sort((a, b) => b.bullishCount - a.bullishCount);
-    const bearish = sentiments
+      .sort((a, b) => (b.bullishCount ?? 0) - (a.bullishCount ?? 0));
+    const bearish = filtered
       .filter((s) => s.consensus === "strong_bearish" || s.consensus === "bearish")
-      .sort((a, b) => b.bearishCount - a.bearishCount);
-    const mixed = sentiments.filter((s) => s.consensus === "mixed");
+      .sort((a, b) => (b.bearishCount ?? 0) - (a.bearishCount ?? 0));
+    const mixed = filtered.filter((s) => s.consensus === "mixed");
 
-    return { bullish, bearish, mixed };
+    const result = {
+      bullish: args.limit ? bullish.slice(0, args.limit) : bullish,
+      bearish: args.limit ? bearish.slice(0, args.limit) : bearish,
+      mixed: args.limit ? mixed.slice(0, args.limit) : mixed,
+    };
+    return result;
   },
 });
 

--- a/convex/superInvestorReads.ts
+++ b/convex/superInvestorReads.ts
@@ -13,28 +13,34 @@ export const investors = query({
 });
 
 export const consensus = query({
-  handler: async (ctx) => {
-    // Get latest period
-    const filings = await ctx.db.query("secFilings").collect();
-    if (filings.length === 0) return { period: null, rankings: { mostHeld: [], biggestBets: [] } };
-    
-    const latestPeriod = filings.sort((a, b) => b.filingDate - a.filingDate)[0].period;
-    
+  args: {
+    period: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    // Get latest period if not provided
+    let targetPeriod = args.period;
+    if (!targetPeriod) {
+      const filings = await ctx.db.query("secFilings").collect();
+      if (filings.length === 0) return { period: null, rankings: { mostHeld: [], biggestBets: [] } };
+      targetPeriod = filings.sort((a, b) => b.filingDate - a.filingDate)[0].period;
+    }
+
     const consensus = await ctx.db
       .query("investorConsensus")
-      .withIndex("by_period", (q) => q.eq("period", latestPeriod))
+      .withIndex("by_period", (q) => q.eq("period", targetPeriod))
       .collect();
-    
+
     const mostHeld = consensus
-      .filter((c) => c.totalInvestors >= 2)
-      .sort((a, b) => b.totalInvestors - a.totalInvestors);
-    
+      .filter((c) => c.totalInvestors && c.totalInvestors >= 2)
+      .sort((a, b) => (b.totalInvestors ?? 0) - (a.totalInvestors ?? 0));
+
     const biggestBets = consensus
-      .sort((a, b) => b.totalValue - a.totalValue)
-      .slice(0, 20);
-    
+      .sort((a, b) => (b.totalValue ?? 0) - (a.totalValue ?? 0))
+      .slice(0, args.limit ?? 20);
+
     return {
-      period: latestPeriod,
+      period: targetPeriod,
       rankings: { mostHeld, biggestBets },
     };
   },
@@ -88,35 +94,77 @@ export const investorPortfolio = query({
   },
 });
 
+export const investorBySlug = query({
+  args: {
+    slug: v.string(),
+    period: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const investor = await ctx.db
+      .query("superInvestors")
+      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
+      .first();
+    if (!investor) return null;
+
+    let targetPeriod = args.period;
+    if (!targetPeriod) {
+      const filings = await ctx.db
+        .query("secFilings")
+        .withIndex("by_cik", (q) => q.eq("cik", investor.cik))
+        .collect();
+      if (filings.length === 0) return null;
+      targetPeriod = filings.sort((a, b) => b.filingDate - a.filingDate)[0].period;
+    }
+
+    const positions = await ctx.db
+      .query("investorPositions")
+      .withIndex("by_cik_period", (q) =>
+        q.eq("cik", investor.cik).eq("period", targetPeriod)
+      )
+      .collect();
+
+    return {
+      investor,
+      period: targetPeriod,
+      positions: positions.sort((a, b) => b.value - a.value),
+    };
+  },
+});
+
 export const notableMoves = query({
-  handler: async (ctx) => {
-    // Get latest period
-    const filings = await ctx.db.query("secFilings").collect();
-    if (filings.length === 0) return { period: null, moves: [] };
-    
-    const latestPeriod = filings.sort((a, b) => b.filingDate - a.filingDate)[0].period;
-    
-    // Get all positions for latest period
+  args: {
+    period: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    // Get latest period if not provided
+    let targetPeriod = args.period;
+    if (!targetPeriod) {
+      const filings = await ctx.db.query("secFilings").collect();
+      if (filings.length === 0) return { period: null, moves: [] };
+      targetPeriod = filings.sort((a, b) => b.filingDate - a.filingDate)[0].period;
+    }
+
+    // Get all positions for target period
     const positions = await ctx.db
       .query("investorPositions")
       .withIndex("by_cik_period")
       .collect();
-    
-    const latestPositions = positions.filter((p) => p.period === latestPeriod);
-    
+
+    const latestPositions = positions.filter((p) => p.period === targetPeriod);
+
     // Filter for notable moves (new, added, reduced, sold)
     const notable = latestPositions
       .filter((p) => p.changeType === "new" || p.changeType === "added" || p.changeType === "reduced" || p.changeType === "sold")
       .sort((a, b) => {
-        // Sort by absolute change pct or by value
         const aScore = Math.abs(a.changePct || 0) * a.value;
         const bScore = Math.abs(b.changePct || 0) * b.value;
         return bScore - aScore;
       })
-      .slice(0, 50);
-    
+      .slice(0, args.limit ?? 50);
+
     return {
-      period: latestPeriod,
+      period: targetPeriod,
       moves: notable,
     };
   },


### PR DESCRIPTION
Fixes "Could not find public function" errors on /influencers page.

- Add superInvestorReads.investorBySlug (needed by /investors/[slug])
- Add optional limit/period args to consensus, notableMoves
- Add optional date/limit args to sentimentRanking
- All queries verified with npx convex run