### PR TITLE
fix(influencer): resolve creators + render digest recommended actions

### DIFF
--- a/convex/influencer.ts
+++ b/convex/influencer.ts
@@ -225,9 +225,34 @@ export const aggregateSentiment = mutation({
     );
     const windowMentions = mentions.filter((m) => videoInWindow.has(m.videoId));
 
+    // Resolve a mention to its creator. Mentions carry the creator either as a
+    // channelId (UC…) or as the influencer document _id (legacy rows), so map
+    // both. Fall back to the parent video's channelId when neither is set.
+    const influencers = await ctx.db.query("influencers").collect();
+    const nameByKey = new Map<string, string>();
+    for (const inf of influencers) {
+      nameByKey.set(inf._id, inf.name);
+      if (inf.channelId) nameByKey.set(inf.channelId, inf.name);
+    }
+    const channelByVideo = new Map<string, string>();
+    for (const v of videos) channelByVideo.set(v.videoId, v.channelId);
+
+    // Stable per-creator key (used to count DISTINCT creators), independent of
+    // how the row happened to store the reference.
+    const actorKey = (m: any): string =>
+      m.influencerId || m.channelId || channelByVideo.get(m.videoId) || "unknown";
+    const nameOf = (key: string): string => nameByKey.get(key) ?? "Unknown creator";
+
     const bySymbol: Record<
       string,
-      { bullish: Set<string>; bearish: Set<string>; neutral: Set<string>; theses: any[]; netScore: number }
+      {
+        bullish: Set<string>;
+        bearish: Set<string>;
+        neutral: Set<string>;
+        theses: any[];
+        netScore: number;
+        companyName: string | null;
+      }
     > = {};
 
     for (const m of windowMentions) {
@@ -238,10 +263,15 @@ export const aggregateSentiment = mutation({
           neutral: new Set(),
           theses: [],
           netScore: 0,
+          companyName: null,
         };
       }
-      bySymbol[m.symbol]![m.stance as "bullish" | "bearish" | "neutral"].add(m.channelId || "unknown");
-      bySymbol[m.symbol]!.theses.push({ influencerId: m.channelId, stance: m.stance, thesis: m.thesis });
+      const key = actorKey(m);
+      bySymbol[m.symbol]![m.stance as "bullish" | "bearish" | "neutral"].add(key);
+      bySymbol[m.symbol]!.theses.push({ influencerId: key, stance: m.stance, thesis: m.thesis });
+      if (!bySymbol[m.symbol]!.companyName && m.companyName) {
+        bySymbol[m.symbol]!.companyName = m.companyName;
+      }
 
       const weight = m.stance === "bullish" ? 1 : m.stance === "bearish" ? -1 : 0;
       const conv = m.conviction === "high" ? 3 : m.conviction === "medium" ? 2 : 1;
@@ -280,8 +310,10 @@ export const aggregateSentiment = mutation({
         bullishCount: bullish,
         bearishCount: bearish,
         neutralCount: neutral,
-        bullishCreators: Array.from(data.bullish),
-        bearishCreators: Array.from(data.bearish),
+        bullishCreators: Array.from(data.bullish).map(nameOf),
+        bearishCreators: Array.from(data.bearish).map(nameOf),
+        neutralCreators: Array.from(data.neutral).map(nameOf),
+        companyName: data.companyName ?? undefined,
         netScore: data.netScore,
         consensus,
         strongestTheses: theses.map((t: any) => t.thesis),
@@ -291,7 +323,7 @@ export const aggregateSentiment = mutation({
 
       const leader = {
         symbol,
-        companyName: null,
+        companyName: data.companyName,
         netScore: data.netScore,
         bullish,
         bearish,
@@ -375,11 +407,18 @@ export const saveDigest = mutation({
     const digest = {
       date: args.date,
       marketSentiment: args.marketSentiment,
+      sentimentLabel: args.sentimentLabel,
       keyThemes: args.keyThemes,
-      sectorRotations: args.sectorRotation?.map((r: any) => `${r.from ?? "?"} → ${r.to ?? "?"}: ${r.rationale}`) ?? [],
+      // Keep the structured shapes the UI renders (actions as {symbol, action,
+      // rationale}; rotations as {from, to, rationale}) instead of flattening
+      // them to strings — flattening was leaving the UI with empty fields.
+      sectorRotation: args.sectorRotation ?? [],
       bullishLeaders: args.bullishLeaders?.map((l: any) => l.symbol) ?? [],
       bearishLeaders: args.bearishLeaders?.map((l: any) => l.symbol) ?? [],
-      recommendedActions: args.recommendedActions?.map((a: any) => `${a.action} — ${a.rationale}`) ?? [],
+      recommendedActions: args.recommendedActions ?? [],
+      videosAnalyzed: args.videosAnalyzed,
+      influencersCount: args.influencersCount,
+      windowDays: args.windowDays,
       createdAt: Date.now(),
     };
 

--- a/src/components/features/influencer-digest.tsx
+++ b/src/components/features/influencer-digest.tsx
@@ -7,16 +7,57 @@ import { SentimentBadge, Pill } from "./influencer-shared";
 
 type Digest = NonNullable<RouterOutputs["influencer"]["latestDigest"]>;
 
+type Action = { action?: string; symbol?: string; rationale?: string };
+type Rotation = { from?: string; to?: string; rationale?: string };
+
+// Recommended actions / rotations may arrive either as structured objects
+// (current job output) or as pre-flattened strings (older digest rows).
+// Normalize both so the UI never renders blank rows.
+function normalizeAction(raw: unknown): Action {
+  if (typeof raw === "string") {
+    const i = raw.indexOf(" — ");
+    return i > -1
+      ? { action: raw.slice(0, i), rationale: raw.slice(i + 3) }
+      : { rationale: raw };
+  }
+  return (raw ?? {}) as Action;
+}
+
+function normalizeRotation(raw: unknown): Rotation {
+  if (typeof raw === "string") {
+    const colon = raw.indexOf(": ");
+    const head = colon > -1 ? raw.slice(0, colon) : "";
+    const rationale = colon > -1 ? raw.slice(colon + 2) : raw;
+    const [from, to] = head.split(" → ").map((s) => s.trim());
+    return { from: from || undefined, to: to || undefined, rationale };
+  }
+  return (raw ?? {}) as Rotation;
+}
+
 export function InfluencerDigest({ digest }: { digest: Digest }) {
+  const rotations: Rotation[] = (
+    ((digest.sectorRotation as unknown[] | undefined) ??
+      (digest as { sectorRotations?: unknown[] }).sectorRotations ??
+      []) as unknown[]
+  ).map(normalizeRotation);
+
+  const actions: Action[] = (
+    (digest.recommendedActions as unknown[] | undefined) ?? []
+  ).map(normalizeAction);
+
+  const meta = [
+    digest.date,
+    digest.videosAnalyzed != null ? `${digest.videosAnalyzed} videos` : null,
+    digest.influencersCount != null ? `${digest.influencersCount} creators` : null,
+    digest.windowDays != null ? `${digest.windowDays}d window` : null,
+  ].filter(Boolean);
+
   return (
     <Card className="border-white/10 bg-white/5 text-white">
       <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
         <div>
           <h2 className="text-lg font-semibold">Daily Market Digest</h2>
-          <p className="text-xs text-gray-400">
-            {digest.date} · {digest.videosAnalyzed} videos · {digest.influencersCount}{" "}
-            creators · {digest.windowDays}d window
-          </p>
+          <p className="text-xs text-gray-400">{meta.join(" · ")}</p>
         </div>
         {digest.sentimentLabel && (
           <SentimentBadge label={digest.sentimentLabel} />
@@ -41,12 +82,12 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
           </div>
         )}
 
-        {(digest.sectorRotation?.length ?? 0) > 0 && (
+        {rotations.length > 0 && (
           <div className="space-y-2">
             <div className="flex items-center gap-1.5 text-xs font-medium text-gray-300">
               <Repeat className="h-3.5 w-3.5" /> Sector rotation
             </div>
-            {digest.sectorRotation.map((r, i) => (
+            {rotations.map((r, i) => (
               <div key={i} className="rounded-md bg-black/20 px-3 py-2 text-sm">
                 {(r.from ?? r.to) && (
                   <div className="mb-0.5 flex items-center gap-1.5 text-xs font-medium text-white">
@@ -61,19 +102,21 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
           </div>
         )}
 
-        {(digest.recommendedActions?.length ?? 0) > 0 && (
+        {actions.length > 0 && (
           <div className="space-y-2">
             <div className="flex items-center gap-1.5 text-xs font-medium text-gray-300">
               <Lightbulb className="h-3.5 w-3.5" /> Recommended actions
             </div>
-            {digest.recommendedActions.map((a, i) => (
+            {actions.map((a, i) => (
               <div
                 key={i}
                 className="flex items-start gap-2 rounded-md bg-black/20 px-3 py-2 text-sm"
               >
-                <Pill className="mt-0.5 shrink-0 bg-purple-500/15 text-purple-200 ring-purple-500/30">
-                  {a.action}
-                </Pill>
+                {a.action && (
+                  <Pill className="mt-0.5 shrink-0 bg-purple-500/15 text-purple-200 ring-purple-500/30">
+                    {a.action}
+                  </Pill>
+                )}
                 <p className="text-gray-300">
                   {a.symbol && (
                     <span className="font-semibold text-white">{a.symbol}: </span>


### PR DESCRIPTION
## Summary

Fixes two data-correctness bugs on `/influencers` (already deployed live; this PR tracks the source).

### 1. Sentiment leaderboard showed "unknown" creators / wrong scores
`aggregateSentiment` deduped creators by `m.channelId`, but mentions store the creator in `influencerId` (channelId is empty). Every creator collapsed into a single `"unknown"` bucket, capping bull/bear counts at 1 and making consensus labels meaningless.

- Resolve creators by `influencerId | channelId` (fallback to the parent video's channel)
- Count **distinct** creators, store their **real names**
- Also populate `neutralCreators` + `companyName` (were never written)

### 2. Daily digest "Recommended actions" rendered blank
`saveDigest` string-flattened the structured `recommendedActions` / `sectorRotation` the job sends (`{symbol, action, rationale}` → `"Accumulate — …"`), so the UI read `undefined` fields. It also never persisted `videosAnalyzed` / `influencersCount` / `windowDays` / `sentimentLabel`.

- `saveDigest` now stores the structured shapes + counts
- `influencer-digest.tsx` normalizes both object and legacy-string forms, so existing rows render immediately and the header no longer prints `undefined`

## Verification
- Re-ran `influencer:aggregateSentiment` → META now shows 6 distinct named creators, PLTR 4 bull / 1 bear, company names populated
- Recommended actions render (Accumulate META, Buy AMZN, etc.)
- Convex functions pushed to `exciting-bee-603`; frontend deployed to Vercel prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)