### PR TITLE
fix(influencer): dedupe per-creator sentiment counts and prevent re-run pileup

### DIFF
--- a/convex/influencer.ts
+++ b/convex/influencer.ts
@@ -179,6 +179,15 @@ export const saveVideoResult = mutation({
     await ctx.db.patch(video._id, patch);
 
     if (args.mentions) {
+      // Idempotency: drop any prior mentions for this video so re-runs
+      // (e.g. re-transcribe + re-extract) don't pile up duplicate rows and
+      // inflate daily sentiment counts.
+      const prior = await ctx.db
+        .query("videoStockMentions")
+        .withIndex("by_videoId", (q) => q.eq("videoId", args.videoId))
+        .collect();
+      for (const old of prior) await ctx.db.delete(old._id);
+
       for (const m of args.mentions) {
         await ctx.db.insert("videoStockMentions", {
           videoId: args.videoId,
@@ -194,6 +203,13 @@ export const saveVideoResult = mutation({
     }
 
     if (args.macro) {
+      // Same idempotency: one macro note per video.
+      const priorMacro = await ctx.db
+        .query("macroNotes")
+        .withIndex("by_videoId", (q) => q.eq("videoId", args.videoId))
+        .collect();
+      for (const old of priorMacro) await ctx.db.delete(old._id);
+
       await ctx.db.insert("macroNotes", {
         videoId: args.videoId,
         channelId: video.channelId,
@@ -237,10 +253,12 @@ export const aggregateSentiment = mutation({
     const channelByVideo = new Map<string, string>();
     for (const v of videos) channelByVideo.set(v.videoId, v.channelId);
 
-    // Stable per-creator key (used to count DISTINCT creators), independent of
-    // how the row happened to store the reference.
+    // Stable per-creator key (used to count DISTINCT creators). Prefer the
+    // channelId since it's the canonical creator key and is always set after
+    // the schema tightening; fall back to the legacy influencerId / parent
+    // video channel for any rows that predate the backfill.
     const actorKey = (m: any): string =>
-      m.influencerId || m.channelId || channelByVideo.get(m.videoId) || "unknown";
+      m.channelId || m.influencerId || channelByVideo.get(m.videoId) || "unknown";
     const nameOf = (key: string): string => nameByKey.get(key) ?? "Unknown creator";
 
     const bySymbol: Record<

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1,4 +1,6 @@
 import { internalMutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
 
 /**
  * One-off cleanup of test/junk seed records (ciks like 999/1234/5678 created
@@ -210,5 +212,62 @@ export const verifyHealth = query({
     }
 
     return { ok: problems.length === 0, problems, checkedAt: Date.now() };
+  },
+});
+
+/**
+ * Repair duplicate `videoStockMentions` rows that accumulated because an
+ * earlier version of `influencer:saveVideoResult` was not idempotent: re-runs
+ * of the same video inserted a fresh mention row on top of the old one,
+ * inflating per-symbol creator counts and the bullishCreators list.
+ *
+ * Keeps the highest-conviction row per (videoId, symbol, stance) and drops
+ * the rest. Run with:
+ *   npx convex run maintenance:dedupeVideoStockMentions
+ */
+export const dedupeVideoStockMentions = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const conv = (c?: string) => (c === "high" ? 3 : c === "medium" ? 2 : c === "low" ? 1 : 0);
+    const all = await ctx.db.query("videoStockMentions").collect();
+    const groups = new Map<string, typeof all>();
+    for (const m of all) {
+      const k = `${m.videoId}|${m.symbol}|${m.stance}`;
+      const arr = groups.get(k) ?? [];
+      arr.push(m);
+      groups.set(k, arr);
+    }
+    let removed = 0;
+    for (const rows of groups.values()) {
+      if (rows.length <= 1) continue;
+      // Keep the row with the strongest conviction; tiebreak on most recent _id.
+      rows.sort((a, b) => {
+        const c = conv(b.conviction) - conv(a.conviction);
+        return c !== 0 ? c : b._id.localeCompare(a._id);
+      });
+      const [keep, ...rest] = rows;
+      for (const r of rest) {
+        await ctx.db.delete(r._id);
+        removed++;
+      }
+    }
+    return { scanned: all.length, duplicatesRemoved: removed, groupsWithDups: [...groups.values()].filter((g) => g.length > 1).length };
+  },
+});
+
+/**
+ * Re-run the influencer sentiment aggregation after fixing the underlying
+ * data. Use after `dedupeVideoStockMentions` to refresh the dailySentiment
+ * table without waiting for the next job. Run with:
+ *   npx convex run maintenance:reaggregateSentiment '{"windowDays":30}'
+ */
+export const reaggregateSentiment = internalMutation({
+  args: { windowDays: v.optional(v.number()) },
+  handler: async (ctx, { windowDays }) => {
+    await ctx.runMutation(internal.influencer.aggregateSentiment, {
+      windowDays: windowDays ?? 30,
+    });
+    const count = (await ctx.db.query("dailySentiment").collect()).length;
+    return { dailySentimentRows: count, windowDays: windowDays ?? 30 };
   },
 });


### PR DESCRIPTION
## Summary

The /influencers leaderboard showed the same creator multiple times for a single stock (e.g. META listed 'Couch Investor' twice, AMZN and NOW listed 'Aria Radnia' twice) and inflated bullish/bearish counts.

## Root cause (two underlying bugs)

1. **`saveVideoResult` was not idempotent.** When the thestockie-influencer job re-transcribed or re-extracted a video (e.g. after a transient failure), it inserted a fresh `videoStockMentions` row on top of the existing one, leaving duplicates for the same `(videoId, symbol, stance)`. Same for `macroNotes`. (4 such duplicate groups were found in prod.)

2. **`aggregateSentiment` mixed-keyed the per-creator dedup.** `actorKey()` preferred the legacy `m.influencerId` field over the canonical `m.channelId`. Because the backfill leaves `influencerId` `undefined` on freshly-inserted rows but populated on legacy rows, the same creator ended up with two distinct actorKeys, defeating the Set-based dedup and producing duplicate creator names in the stored array.

## Fix

- **`convex/influencer.ts`:**
  - `saveVideoResult`: clear prior `videoStockMentions` and `macroNotes` rows for the video before inserting new ones (idempotent re-runs).
  - `aggregateSentiment`: `actorKey()` now prefers `m.channelId` (the canonical creator key, always set after the schema tightening) and only falls back to `influencerId` / parent video for any rows that predate the backfill.

- **`convex/maintenance.ts`** (new):
  - `maintenance:dedupeVideoStockMentions` — drops duplicate mention rows.
  - `maintenance:reaggregateSentiment` — re-runs aggregation cleanly.

## Verification (live deployment, `exciting-bee-603`)

```
=== dedupeVideoStockMentions ===
{ "duplicatesRemoved": 4, "groupsWithDups": 4, "scanned": 446 }

=== reaggregateSentiment (windowDays=30) ===
{ "dailySentimentRows": 187, "windowDays": 30 }

=== post-fix duplicate check ===
{ "rowsWithDups": 0, "totalRows": 187 }   ← was 32/187 before
```

Spot check on the stocks from the report:
- **META**: `bullishCount` 10 → **7** unique creators, no duplicates.
- **AMZN**: `bullishCount` 6 → **5** unique creators, no duplicates.
- **NOW**: `bullishCount` 4 → **4** unique creators, no duplicates.

## Rebase note

This PR was rebased onto `main` after `b9a4234` ("chore(influencer): tighten ingest validators + add health check") added the actorKey/nameOf resolution path. The aggregator's `actorKey` precedence change here complements (not duplicates) that work.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>