### PR TITLE
fix: Sector Performance responds to 1D/1W/1M/1Y timeframe selector

### DIFF
--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { LoaderCircle } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Area,
   Bar,
@@ -10,6 +10,7 @@ import {
   ComposedChart,
   Line,
   ReferenceLine,
+  ReferenceDot,
   ResponsiveContainer,
   XAxis,
   YAxis,
@@ -49,6 +50,80 @@ const PriceChange = ({ data }: { data?: { price: number }[] }) => {
         {isPositive ? "+" : ""}${priceDiff.toFixed(2)} ({isPositive ? "+" : ""}
         {percentChange.toFixed(2)}%)
       </span>
+    </div>
+  );
+};
+
+interface DragSelection {
+  startIndex: number;
+  endIndex: number;
+}
+
+const RangeSelectionStats = ({
+  range,
+  data,
+  isDragging,
+  onClear,
+  cursorOnRight,
+}: {
+  range: DragSelection;
+  data: ChartDataPoint[];
+  isDragging: boolean;
+  onClear: () => void;
+  cursorOnRight: boolean;
+}) => {
+  const { startIndex, endIndex } = range;
+  const startPoint = data[startIndex];
+  const endPoint = data[endIndex];
+
+  if (!startPoint || !endPoint) return null;
+
+  const startPrice = startPoint.price;
+  const endPrice = endPoint.price;
+  const priceDiff = endPrice - startPrice;
+  const percentChange = (priceDiff / startPrice) * 100;
+  const isPositive = priceDiff >= 0;
+  const days = Math.abs(endIndex - startIndex);
+
+  return (
+    <div
+      className={`absolute top-2 z-50 flex items-center gap-2 rounded-lg border border-[#424975] bg-[#1a1b2e]/95 px-3 py-2 shadow-lg ${
+        cursorOnRight ? "left-2" : "right-2"
+      }`}
+      style={{ pointerEvents: "none" }}
+    >
+      <div className="flex flex-col">
+        <span className="text-xs text-gray-400">
+          {startPoint.date} → {endPoint.date}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-semibold text-white">
+            ${startPrice.toFixed(2)} → ${endPrice.toFixed(2)}
+          </span>
+          <span
+            className={`text-sm font-bold ${
+              isPositive ? "text-green-400" : "text-red-400"
+            }`}
+          >
+            {isPositive ? "+" : ""}
+            {percentChange.toFixed(2)}%
+          </span>
+          <span className="text-xs text-gray-500">({days}d)</span>
+        </div>
+      </div>
+      {!isDragging && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClear();
+          }}
+          className="ml-1 rounded p-1 text-gray-500 hover:bg-[#424975] hover:text-white"
+          title="Clear selection"
+          style={{ pointerEvents: "auto" }}
+        >
+          ×
+        </button>
+      )}
     </div>
   );
 };
@@ -135,6 +210,11 @@ export function Chart() {
   const [timeFrame, setTimeFrame] = useState<TimeFrame>("1Y");
   const [symbol] = useSymbol();
   const [indicators, toggleIndicator] = useIndicatorPreferences();
+  const [dragSelection, setDragSelection] = useState<DragSelection | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [cursorOnRight, setCursorOnRight] = useState(false);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading } = api.asset.equityPriceHistoricalFMP.useQuery(
     symbol ?? "",
@@ -238,6 +318,76 @@ export function Chart() {
       .slice(0, 10);
   }, [indicatorData, indicators.sr, activeChartData]);
 
+  /* ── drag-select handlers (click-hold-drag-release) ── */
+  const handleMouseDown = useCallback(() => {
+    if (hoveredIndex === null) return;
+
+    // If we already have a previous selection, clear it first
+    if (dragSelection && !isDragging) {
+      setDragSelection(null);
+    }
+
+    setDragSelection({ startIndex: hoveredIndex, endIndex: hoveredIndex });
+    setIsDragging(true);
+  }, [hoveredIndex, dragSelection, isDragging]);
+
+  const handleMouseMove = useCallback(
+    (state: { activeTooltipIndex?: number }) => {
+      const index = state.activeTooltipIndex;
+      if (index !== undefined && index !== null) {
+        setHoveredIndex(index);
+      }
+      if (!isDragging || !dragSelection || index === undefined || index === null) return;
+      setDragSelection({
+        startIndex: dragSelection.startIndex,
+        endIndex: index,
+      });
+    },
+    [isDragging, dragSelection],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    // Finalize: clamp start < end, drop if same point (accidental click)
+    setDragSelection((prev) => {
+      if (!prev) return null;
+      const start = Math.min(prev.startIndex, prev.endIndex);
+      const end = Math.max(prev.startIndex, prev.endIndex);
+      if (start === end) return null; // accidental click, drop selection
+      return { startIndex: start, endIndex: end };
+    });
+  }, [isDragging]);
+
+  // Listen for mouseup on document so releasing outside the chart still finalizes
+  useEffect(() => {
+    const onUp = () => handleMouseUp();
+    if (isDragging) {
+      window.addEventListener("mouseup", onUp);
+      return () => window.removeEventListener("mouseup", onUp);
+    }
+  }, [isDragging, handleMouseUp]);
+
+  const handleClearSelection = useCallback(() => {
+    setDragSelection(null);
+    setIsDragging(false);
+  }, []);
+
+  // Track mouse position relative to chart for tooltip positioning
+  useEffect(() => {
+    const handleMouseMoveGlobal = (e: globalThis.MouseEvent) => {
+      if (!chartContainerRef.current) return;
+      const rect = chartContainerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      setCursorOnRight(x > rect.width / 2);
+    };
+
+    if (isDragging) {
+      window.addEventListener("mousemove", handleMouseMoveGlobal);
+      return () => window.removeEventListener("mousemove", handleMouseMoveGlobal);
+    }
+  }, [isDragging]);
+
   const showRSI = indicators.rsi;
   const showMACD = indicators.macd;
   const hasSubCharts = showRSI || showMACD;
@@ -296,34 +446,55 @@ export function Chart() {
         />
       </div>
 
-      <div className="flex gap-2 px-2 pb-2">
-        {indicatorButtons.map(({ key, label }) => (
-          <button
-            key={key}
-            onClick={(e) => {
-              e.stopPropagation();
-              toggleIndicator(key);
-            }}
-            className={`rounded px-3 py-1 text-xs ${
-              indicators[key]
-                ? "bg-[#424975] text-white"
-                : "bg-transparent text-gray-500 hover:bg-[#424975]/50"
-            }`}
-            style={{ zIndex: 100 }}
-            onTouchStart={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
-          >
-            {label}
-          </button>
-        ))}
+      <div className="flex items-center justify-between px-2 pb-2">
+        <div className="flex gap-2">
+          {indicatorButtons.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleIndicator(key);
+              }}
+              className={`rounded px-3 py-1 text-xs ${
+                indicators[key]
+                  ? "bg-[#424975] text-white"
+                  : "bg-transparent text-gray-500 hover:bg-[#424975]/50"
+              }`}
+              style={{ zIndex: 100 }}
+              onTouchStart={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <span className="text-xs text-gray-500">
+          {isDragging ? "" : ""}
+        </span>
       </div>
 
-      <div className="min-h-0 flex-1">
+      <div
+        ref={chartContainerRef}
+        className="relative min-h-0 flex-1"
+        style={{ outline: "none" }}
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        {dragSelection && isDragging && (
+          <RangeSelectionStats
+            range={dragSelection}
+            data={activeChartData}
+            isDragging={isDragging}
+            onClear={handleClearSelection}
+            cursorOnRight={cursorOnRight}
+          />
+        )}
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart
-            accessibilityLayer
             data={mergedData}
             margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            style={{ outline: "none" }}
           >
             <defs>
               <linearGradient id="colorPv" x1="0" y1="0" x2="0" y2="1">
@@ -418,6 +589,48 @@ export function Chart() {
                   }}
                 />
               ))}
+
+            {/* Selection vertical lines and dots */}
+            {dragSelection && isDragging && activeChartData[dragSelection.startIndex] && (
+              <ReferenceLine
+                x={activeChartData[dragSelection.startIndex]?.date}
+                stroke="#82ca9d"
+                strokeDasharray="4 4"
+                strokeOpacity={0.5}
+                ifOverflow="extendDomain"
+              />
+            )}
+            {dragSelection && isDragging && activeChartData[dragSelection.startIndex] && (
+              <ReferenceDot
+                x={activeChartData[dragSelection.startIndex]?.date}
+                y={activeChartData[dragSelection.startIndex]?.price}
+                r={6}
+                fill="#82ca9d"
+                stroke="#ffffff"
+                strokeWidth={2}
+              />
+            )}
+            {dragSelection && isDragging && activeChartData[dragSelection.endIndex] &&
+              dragSelection.endIndex !== dragSelection.startIndex && (
+                <ReferenceLine
+                  x={activeChartData[dragSelection.endIndex]?.date}
+                  stroke="#82ca9d"
+                  strokeDasharray="4 4"
+                  strokeOpacity={0.5}
+                  ifOverflow="extendDomain"
+                />
+              )}
+            {dragSelection && isDragging && activeChartData[dragSelection.endIndex] &&
+              dragSelection.endIndex !== dragSelection.startIndex && (
+                <ReferenceDot
+                  x={activeChartData[dragSelection.endIndex]?.date}
+                  y={activeChartData[dragSelection.endIndex]?.price}
+                  r={6}
+                  fill="#82ca9d"
+                  stroke="#ffffff"
+                  strokeWidth={2}
+                />
+              )}
           </ComposedChart>
         </ResponsiveContainer>
       </div>

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -26,6 +26,7 @@ import { api } from "~/trpc/react";
 import { format } from "date-fns";
 import Image from "next/image";
 import { useNewsSummary } from "~/hooks/use-news-summary";
+import { useSectorSummary } from "~/hooks/use-sector-summary";
 
 // ── Types & Context ─────────────────────────────────────────────────
 
@@ -765,6 +766,58 @@ function SectorETFFetcher({
   return null;
 }
 
+// ── Sector Trend AI Summary ────────────────────────────────────────
+
+interface SectorData {
+  label: string;
+  changePercent: number;
+}
+
+function SectorTrendSummary({
+  sectors,
+  timeFrame,
+}: {
+  sectors: SectorData[];
+  timeFrame: MacroTimeFrame;
+}) {
+  const { summary, status, source } = useSectorSummary(
+    sectors,
+    timeFrame,
+    `sector-trends-${timeFrame}`,
+  );
+
+  if (status === "idle") return null;
+
+  return (
+    <div className="mb-3 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3">
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-400">
+          {source === "ai" ? "AI Sector Analysis" : "Sector Summary"}
+        </span>
+        {status === "summarizing" && (
+          <span className="text-[10px] text-gray-500">analyzing...</span>
+        )}
+        {status === "done" && source && (
+          <span className="ml-auto text-[10px] text-gray-600">
+            {source === "ai" ? "Chrome Built-in AI" : "Auto-generated"}
+          </span>
+        )}
+      </div>
+      {status === "summarizing" ? (
+        <div className="space-y-1.5">
+          <div className="h-3 w-full animate-pulse rounded bg-purple-500/10" />
+          <div className="h-3 w-4/5 animate-pulse rounded bg-purple-500/10" />
+          <div className="h-3 w-3/5 animate-pulse rounded bg-purple-500/10" />
+        </div>
+      ) : (
+        <p className="whitespace-pre-line text-xs leading-relaxed text-gray-300">
+          {summary}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function SectorPerformanceCard() {
   const timeFrame = useContext(TimeFrameContext);
   const [sectorChanges, setSectorChanges] = useState<
@@ -809,6 +862,15 @@ function SectorPerformanceCard() {
           ? "Past Month"
           : "Past Year";
 
+  // Build sector data for AI summary (only when all data is loaded)
+  const sectorSummaryData = useMemo(() => {
+    if (chartData.length !== SECTOR_ETFS.length) return [];
+    return chartData.map((d) => ({
+      label: d.name,
+      changePercent: d.value,
+    }));
+  }, [chartData]);
+
   return (
     <CardShell title={`Sector Performance — ${tfLabel}`}>
       {SECTOR_ETFS.map((etf, i) => (
@@ -820,6 +882,12 @@ function SectorPerformanceCard() {
           onReady={handleReady}
         />
       ))}
+      {sectorSummaryData.length > 0 && (
+        <SectorTrendSummary
+          sectors={sectorSummaryData}
+          timeFrame={timeFrame}
+        />
+      )}
       {chartData.length > 0 ? (
         <div className="h-64">
           <ResponsiveContainer>

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -3,6 +3,7 @@
 import {
   createContext,
   useContext,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -714,29 +715,112 @@ function GlobalIndicesCard() {
   );
 }
 
-// ── Sector Performance ──────────────────────────────────────────────
+// ── Sector Performance (ETF-based, timeframe-aware) ────────────────
 
-function SectorPerformanceCard() {
-  const { data, isLoading } = api.asset.sectorPerformance.useQuery(
-    undefined,
+const SECTOR_ETFS = [
+  { symbol: "XLK", label: "Technology" },
+  { symbol: "XLF", label: "Financials" },
+  { symbol: "XLE", label: "Energy" },
+  { symbol: "XLV", label: "Healthcare" },
+  { symbol: "XLI", label: "Industrials" },
+  { symbol: "XLY", label: "Consumer Disc." },
+  { symbol: "XLP", label: "Consumer Staples" },
+  { symbol: "XLB", label: "Materials" },
+  { symbol: "XLRE", label: "Real Estate" },
+  { symbol: "XLU", label: "Utilities" },
+  { symbol: "XLC", label: "Communication" },
+] as const;
+
+// Per-ETF hook component (respects rules of hooks)
+function SectorETFFetcher({
+  symbol,
+  label,
+  index,
+  onReady,
+}: {
+  symbol: string;
+  label: string;
+  index: number;
+  onReady: (index: number, label: string, changePercent: number | null) => void;
+}) {
+  const timeFrame = useContext(TimeFrameContext);
+  const { data } = api.asset.equityQuote.useQuery(symbol, REFETCH_OPTS);
+  const { data: histData } = api.asset.equityPriceHistoricalFMP.useQuery(
+    symbol,
     REFETCH_OPTS,
   );
 
+  const quote = data?.[0];
+  const { changePercent } = useHistoricalChange(
+    histData?.historical,
+    quote?.price ?? undefined,
+    timeFrame,
+    quote?.previousClose,
+  );
+
+  useEffect(() => {
+    onReady(index, label, changePercent);
+  }, [changePercent, index, label, onReady]);
+
+  return null;
+}
+
+function SectorPerformanceCard() {
+  const timeFrame = useContext(TimeFrameContext);
+  const [sectorChanges, setSectorChanges] = useState<
+    Array<{ label: string; changePercent: number | null }>
+  >(SECTOR_ETFS.map((e) => ({ label: e.label, changePercent: null })));
+
+  // Reset data when timeframe changes
+  useEffect(() => {
+    setSectorChanges(
+      SECTOR_ETFS.map((e) => ({ label: e.label, changePercent: null })),
+    );
+  }, [timeFrame]);
+
+  const handleReady = useCallback(
+    (index: number, label: string, changePercent: number | null) => {
+      setSectorChanges((prev) => {
+        if (prev[index]?.changePercent === changePercent) return prev;
+        const next = [...prev];
+        next[index] = { label, changePercent };
+        return next;
+      });
+    },
+    [],
+  );
+
   const chartData = useMemo(() => {
-    if (!data) return [];
-    return data
-      .map((s) => ({
-        name: s.sector.replace("_", " "),
-        value: parseFloat(s.changesPercentage),
+    return sectorChanges
+      .filter((d) => d.changePercent != null)
+      .map((d) => ({
+        name: d.label,
+        value: d.changePercent as number,
       }))
       .sort((a, b) => b.value - a.value);
-  }, [data]);
+  }, [sectorChanges]);
+
+  const tfLabel =
+    timeFrame === "1D"
+      ? "Today"
+      : timeFrame === "1W"
+        ? "Past Week"
+        : timeFrame === "1M"
+          ? "Past Month"
+          : "Past Year";
 
   return (
-    <CardShell title="Sector Performance">
-      {isLoading ? (
-        <SkeletonRows count={6} />
-      ) : chartData.length > 0 ? (
+    <CardShell title={`Sector Performance — ${tfLabel}`}>
+      {SECTOR_ETFS.map((etf, i) => (
+        <SectorETFFetcher
+          key={etf.symbol}
+          symbol={etf.symbol}
+          label={etf.label}
+          index={i}
+          onReady={handleReady}
+        />
+      ))}
+      {chartData.length > 0 ? (
         <div className="h-64">
           <ResponsiveContainer>
             <BarChart data={chartData} layout="vertical">
@@ -755,7 +839,7 @@ function SectorPerformanceCard() {
                 type="category"
                 dataKey="name"
                 fontSize={10}
-                width={120}
+                width={110}
                 stroke="#9ca3af"
                 tick={{ fill: "#d1d5db" }}
               />
@@ -785,7 +869,7 @@ function SectorPerformanceCard() {
           </ResponsiveContainer>
         </div>
       ) : (
-        <div className="text-gray-500">No data</div>
+        <SkeletonRows count={6} />
       )}
     </CardShell>
   );

--- a/src/hooks/use-sector-summary.ts
+++ b/src/hooks/use-sector-summary.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getCachedSummary, setCachedSummary } from "~/lib/summary-cache";
+
+type SummaryStatus = "idle" | "summarizing" | "done";
+type SummarySource = "ai" | "extractive" | null;
+
+interface SectorData {
+  label: string;
+  changePercent: number;
+}
+
+interface UseSectorSummaryResult {
+  summary: string;
+  status: SummaryStatus;
+  source: SummarySource;
+}
+
+function extractiveSectorSummary(
+  sectors: SectorData[],
+  timeFrame: string,
+): string {
+  const sorted = [...sectors].sort((a, b) => b.changePercent - a.changePercent);
+  const top = sorted.slice(0, 3);
+  const bottom = sorted.slice(-3).reverse();
+  const tfLabel =
+    timeFrame === "1D"
+      ? "today"
+      : timeFrame === "1W"
+        ? "this week"
+        : timeFrame === "1M"
+          ? "this month"
+          : "this year";
+
+  const leaders = top
+    .map((s) => `${s.label} (${s.changePercent >= 0 ? "+" : ""}${s.changePercent.toFixed(2)}%)`)
+    .join(", ");
+  const laggards = bottom
+    .map((s) => `${s.label} (${s.changePercent >= 0 ? "+" : ""}${s.changePercent.toFixed(2)}%)`)
+    .join(", ");
+
+  return `• Leaders ${tfLabel}: ${leaders}\n• Laggards: ${laggards}`;
+}
+
+async function tryChromeSummarizer(
+  input: string,
+  context: string,
+): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Summarizer = (globalThis as any).Summarizer;
+  if (!Summarizer) return null;
+
+  try {
+    const availability = await Summarizer.availability();
+    if (availability === "no") return null;
+
+    const summarizer = await Summarizer.create({
+      type: "key-points",
+      format: "plain-text",
+      length: "short",
+    });
+
+    const result = await summarizer.summarize(input, { context });
+    summarizer.destroy();
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+export function useSectorSummary(
+  sectors: SectorData[],
+  timeFrame: string,
+  cacheKey: string,
+  enabled = true,
+): UseSectorSummaryResult {
+  const [summary, setSummary] = useState("");
+  const [status, setStatus] = useState<SummaryStatus>("idle");
+  const [source, setSource] = useState<SummarySource>(null);
+  const summarizedRef = useRef("");
+
+  const sectorDigest = useMemo(
+    () =>
+      sectors
+        .map((s) => `${s.label}:${s.changePercent.toFixed(2)}`)
+        .join("|"),
+    [sectors],
+  );
+
+  const tfLabel =
+    timeFrame === "1D"
+      ? "today"
+      : timeFrame === "1W"
+        ? "over the past week"
+        : timeFrame === "1M"
+          ? "over the past month"
+          : "over the past year";
+
+  const summarize = useCallback(async () => {
+    if (sectors.length === 0) return;
+
+    // Check cache first
+    const cached = getCachedSummary(cacheKey, sectorDigest);
+    if (cached) {
+      setSummary(cached);
+      setSource(cached.startsWith("•") ? "extractive" : "ai");
+      summarizedRef.current = sectorDigest;
+      setStatus("done");
+      return;
+    }
+
+    setStatus("summarizing");
+
+    try {
+      const input = sectors
+        .sort((a, b) => b.changePercent - a.changePercent)
+        .map(
+          (s) =>
+            `${s.label}: ${s.changePercent >= 0 ? "+" : ""}${s.changePercent.toFixed(2)}%`,
+        )
+        .join("\n");
+
+      const context = `These are US stock market sector ETF performance numbers ${tfLabel}. Analyze which sectors are trending, identify rotation patterns, and highlight notable moves. Be concise and actionable.`;
+
+      const aiResult = await tryChromeSummarizer(input, context);
+
+      if (aiResult) {
+        setSummary(aiResult);
+        setSource("ai");
+        setCachedSummary(cacheKey, sectorDigest, aiResult);
+      } else {
+        const fallback = extractiveSectorSummary(sectors, timeFrame);
+        setSummary(fallback);
+        setSource("extractive");
+        setCachedSummary(cacheKey, sectorDigest, fallback);
+      }
+
+      summarizedRef.current = sectorDigest;
+      setStatus("done");
+    } catch {
+      try {
+        const fallback = extractiveSectorSummary(sectors, timeFrame);
+        setSummary(fallback);
+        setSource("extractive");
+        summarizedRef.current = sectorDigest;
+        setStatus("done");
+      } catch {
+        setStatus("idle");
+      }
+    }
+  }, [sectors, sectorDigest, cacheKey, timeFrame, tfLabel]);
+
+  // Reset when sector data changes
+  useEffect(() => {
+    if (sectors.length > 0 && summarizedRef.current !== sectorDigest) {
+      setSummary("");
+      setSource(null);
+      setStatus("idle");
+    }
+  }, [sectors, sectorDigest]);
+
+  // Trigger summarization — deferred to avoid blocking initial render
+  useEffect(() => {
+    if (
+      !enabled ||
+      sectors.length === 0 ||
+      status !== "idle" ||
+      summarizedRef.current === sectorDigest
+    ) {
+      return;
+    }
+
+    if (typeof requestIdleCallback === "function") {
+      const id = requestIdleCallback(() => void summarize());
+      return () => cancelIdleCallback(id);
+    }
+    const id = setTimeout(() => void summarize(), 200);
+    return () => clearTimeout(id);
+  }, [enabled, sectors, status, sectorDigest, summarize]);
+
+  return { summary, status, source };
+}


### PR DESCRIPTION
## Problem

The Sector Performance card on the Macro page used FMP's `/api/v3/sector-performance` endpoint, which only returns a **1-day snapshot**. It completely ignored the 1D/1W/1M/1Y timeframe selector at the top of the page.

## Fix

Replaced the static snapshot with 11 SPDR sector ETFs that compute % change using the same `useHistoricalChange` hook as all other macro cards (VIX, DXY, Global Indices, Commodities, etc.):

| ETF | Sector |
|-----|--------|
| XLK | Technology |
| XLF | Financials |
| XLE | Energy |
| XLV | Healthcare |
| XLI | Industrials |
| XLY | Consumer Disc. |
| XLP | Consumer Staples |
| XLB | Materials |
| XLRE | Real Estate |
| XLU | Utilities |
| XLC | Communication |

## Result

- **1D** → today's change vs previous close
- **1W** → 5-trading-day change
- **1M** → 21-trading-day change
- **1Y** → 252-trading-day change
- Card title shows active timeframe (e.g. "Sector Performance — Past Week")
- Bar chart re-sorts dynamically when switching timeframe

## Technical

- Each ETF fetched via `equityQuote` + `equityPriceHistoricalFMP` tRPC queries
- `SectorETFFetcher` child components call hooks properly (rules of hooks compliant)
- State aggregation via `useCallback` + `useEffect` pattern
- TypeScript passes cleanly