### PR TITLE
feat: AI sector trend analysis using Chrome Built-in AI

### DIFF
--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -25,6 +25,7 @@ import { api } from "~/trpc/react";
 import { format } from "date-fns";
 import Image from "next/image";
 import { useNewsSummary } from "~/hooks/use-news-summary";
+import { useSectorSummary } from "~/hooks/use-sector-summary";
 
 // ── Types & Context ─────────────────────────────────────────────────
 
@@ -716,6 +717,58 @@ function GlobalIndicesCard() {
 
 // ── Sector Performance ──────────────────────────────────────────────
 
+// ── Sector Trend AI Summary ────────────────────────────────────────
+
+interface SectorData {
+  label: string;
+  changePercent: number;
+}
+
+function SectorTrendSummary({
+  sectors,
+  timeFrame,
+}: {
+  sectors: SectorData[];
+  timeFrame: MacroTimeFrame;
+}) {
+  const { summary, status, source } = useSectorSummary(
+    sectors,
+    timeFrame,
+    `sector-trends-${timeFrame}`,
+  );
+
+  if (status === "idle") return null;
+
+  return (
+    <div className="mb-3 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3">
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-400">
+          {source === "ai" ? "AI Sector Analysis" : "Sector Summary"}
+        </span>
+        {status === "summarizing" && (
+          <span className="text-[10px] text-gray-500">analyzing...</span>
+        )}
+        {status === "done" && source && (
+          <span className="ml-auto text-[10px] text-gray-600">
+            {source === "ai" ? "Chrome Built-in AI" : "Auto-generated"}
+          </span>
+        )}
+      </div>
+      {status === "summarizing" ? (
+        <div className="space-y-1.5">
+          <div className="h-3 w-full animate-pulse rounded bg-purple-500/10" />
+          <div className="h-3 w-4/5 animate-pulse rounded bg-purple-500/10" />
+          <div className="h-3 w-3/5 animate-pulse rounded bg-purple-500/10" />
+        </div>
+      ) : (
+        <p className="whitespace-pre-line text-xs leading-relaxed text-gray-300">
+          {summary}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function SectorPerformanceCard() {
   const timeFrame = useContext(TimeFrameContext);
   const { data, isLoading } = api.asset.sectorPerformanceTimeframe.useQuery(
@@ -771,12 +824,27 @@ function SectorPerformanceCard() {
 
   const fmtPct = (v: number) => (v >= 0 ? "+" : "") + v.toFixed(1) + "%";
 
+  // Build sector data for AI summary (only when all data is loaded)
+  const sectorSummaryData = useMemo(() => {
+    if (chartData.length !== SECTOR_ETFS.length) return [];
+    return chartData.map((d) => ({
+      label: d.name,
+      changePercent: d.value,
+    }));
+  }, [chartData]);
+
   return (
     <CardShell title={`Sector Performance · ${timeFrame}`}>
       {isLoading ? (
         <SkeletonRows count={6} />
       ) : chartData.length > 0 ? (
         <>
+      {sectorSummaryData.length > 0 && (
+        <SectorTrendSummary
+          sectors={sectorSummaryData}
+          timeFrame={timeFrame}
+        />
+      )}
         <div className="h-64">
           <ResponsiveContainer>
             <BarChart data={chartData} layout="vertical">

--- a/src/hooks/use-sector-summary.ts
+++ b/src/hooks/use-sector-summary.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getCachedSummary, setCachedSummary } from "~/lib/summary-cache";
+
+type SummaryStatus = "idle" | "summarizing" | "done";
+type SummarySource = "ai" | "extractive" | null;
+
+interface SectorData {
+  label: string;
+  changePercent: number;
+}
+
+interface UseSectorSummaryResult {
+  summary: string;
+  status: SummaryStatus;
+  source: SummarySource;
+}
+
+function extractiveSectorSummary(
+  sectors: SectorData[],
+  timeFrame: string,
+): string {
+  const sorted = [...sectors].sort((a, b) => b.changePercent - a.changePercent);
+  const top = sorted.slice(0, 3);
+  const bottom = sorted.slice(-3).reverse();
+  const tfLabel =
+    timeFrame === "1D"
+      ? "today"
+      : timeFrame === "1W"
+        ? "this week"
+        : timeFrame === "1M"
+          ? "this month"
+          : "this year";
+
+  const leaders = top
+    .map((s) => `${s.label} (${s.changePercent >= 0 ? "+" : ""}${s.changePercent.toFixed(2)}%)`)
+    .join(", ");
+  const laggards = bottom
+    .map((s) => `${s.label} (${s.changePercent >= 0 ? "+" : ""}${s.changePercent.toFixed(2)}%)`)
+    .join(", ");
+
+  return `• Leaders ${tfLabel}: ${leaders}\n• Laggards: ${laggards}`;
+}
+
+async function tryChromeSummarizer(
+  input: string,
+  context: string,
+): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Summarizer = (globalThis as any).Summarizer;
+  if (!Summarizer) return null;
+
+  try {
+    const availability = await Summarizer.availability();
+    if (availability === "no") return null;
+
+    const summarizer = await Summarizer.create({
+      type: "key-points",
+      format: "plain-text",
+      length: "short",
+    });
+
+    const result = await summarizer.summarize(input, { context });
+    summarizer.destroy();
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+export function useSectorSummary(
+  sectors: SectorData[],
+  timeFrame: string,
+  cacheKey: string,
+  enabled = true,
+): UseSectorSummaryResult {
+  const [summary, setSummary] = useState("");
+  const [status, setStatus] = useState<SummaryStatus>("idle");
+  const [source, setSource] = useState<SummarySource>(null);
+  const summarizedRef = useRef("");
+
+  const sectorDigest = useMemo(
+    () =>
+      sectors
+        .map((s) => `${s.label}:${s.changePercent.toFixed(2)}`)
+        .join("|"),
+    [sectors],
+  );
+
+  const tfLabel =
+    timeFrame === "1D"
+      ? "today"
+      : timeFrame === "1W"
+        ? "over the past week"
+        : timeFrame === "1M"
+          ? "over the past month"
+          : "over the past year";
+
+  const summarize = useCallback(async () => {
+    if (sectors.length === 0) return;
+
+    // Check cache first
+    const cached = getCachedSummary(cacheKey, sectorDigest);
+    if (cached) {
+      setSummary(cached);
+      setSource(cached.startsWith("•") ? "extractive" : "ai");
+      summarizedRef.current = sectorDigest;
+      setStatus("done");
+      return;
+    }
+
+    setStatus("summarizing");
+
+    try {
+      const input = sectors
+        .sort((a, b) => b.changePercent - a.changePercent)
+        .map(
+          (s) =>
+            `${s.label}: ${s.changePercent >= 0 ? "+" : ""}${s.changePercent.toFixed(2)}%`,
+        )
+        .join("\n");
+
+      const context = `These are US stock market sector ETF performance numbers ${tfLabel}. Analyze which sectors are trending, identify rotation patterns, and highlight notable moves. Be concise and actionable.`;
+
+      const aiResult = await tryChromeSummarizer(input, context);
+
+      if (aiResult) {
+        setSummary(aiResult);
+        setSource("ai");
+        setCachedSummary(cacheKey, sectorDigest, aiResult);
+      } else {
+        const fallback = extractiveSectorSummary(sectors, timeFrame);
+        setSummary(fallback);
+        setSource("extractive");
+        setCachedSummary(cacheKey, sectorDigest, fallback);
+      }
+
+      summarizedRef.current = sectorDigest;
+      setStatus("done");
+    } catch {
+      try {
+        const fallback = extractiveSectorSummary(sectors, timeFrame);
+        setSummary(fallback);
+        setSource("extractive");
+        summarizedRef.current = sectorDigest;
+        setStatus("done");
+      } catch {
+        setStatus("idle");
+      }
+    }
+  }, [sectors, sectorDigest, cacheKey, timeFrame, tfLabel]);
+
+  // Reset when sector data changes
+  useEffect(() => {
+    if (sectors.length > 0 && summarizedRef.current !== sectorDigest) {
+      setSummary("");
+      setSource(null);
+      setStatus("idle");
+    }
+  }, [sectors, sectorDigest]);
+
+  // Trigger summarization — deferred to avoid blocking initial render
+  useEffect(() => {
+    if (
+      !enabled ||
+      sectors.length === 0 ||
+      status !== "idle" ||
+      summarizedRef.current === sectorDigest
+    ) {
+      return;
+    }
+
+    if (typeof requestIdleCallback === "function") {
+      const id = requestIdleCallback(() => void summarize());
+      return () => cancelIdleCallback(id);
+    }
+    const id = setTimeout(() => void summarize(), 200);
+    return () => clearTimeout(id);
+  }, [enabled, sectors, status, sectorDigest, summarize]);
+
+  return { summary, status, source };
+}


### PR DESCRIPTION
## What

Adds an AI-powered sector trend summary to the Sector Performance card on the Macro dashboard. Uses the browser's Built-in AI (Chrome's  API) to generate a natural-language analysis of sector performance.

## Details

- New hook `use-sector-summary.ts` — sends sector ETF % changes to the browser's AI model and receives a trend narrative
- `SectorTrendSummary` component in `macro-dashboard.tsx` — renders the AI summary above the chart
- Falls back gracefully when AI is unavailable (no `window.ai` support)
- Only triggers when all sector data is loaded

## Conflicts Resolved

Rebased onto current main (which includes PR #41's sector performance timeframe fix). The AI summary now sits inside the new `chartData.length > 0` conditional block.