### PR TITLE
feat(theme): adopt @mtosity/design-system — dark theme + switcher

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@mtosity:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
-    "@mtosity/design-system": "0.2.0",
+    "@mtosity/design-system": "0.3.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
+    "@mtosity/design-system": "0.1.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
-    "@mtosity/design-system": "0.1.0",
+    "@mtosity/design-system": "0.2.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.9.1(react-hook-form@7.54.0(react@19.0.0))
+      '@mtosity/design-system':
+        specifier: 0.1.0
+        version: 0.1.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.1
         version: 1.2.1(@types/react-dom@18.3.2)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -748,6 +751,14 @@ packages:
 
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
+
+  '@mtosity/design-system@0.1.0':
+    resolution: {integrity: sha512-IXgLC3DUhjm/JC2Hwl+4/I6bCOw69k4nUt7gJfW/Q7MbOCy//WYI6PkJ+vDdxgl5pU3RfS8yqVYVT/VeSmz7Fw==, tarball: https://npm.pkg.github.com/download/@mtosity/design-system/0.1.0/1239a476f672f8c0d84bf4a5dee67a57942b109c}
+    peerDependencies:
+      framer-motion: ^12.0.0
+      next: '>=15'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -2946,6 +2957,20 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -3667,6 +3692,12 @@ packages:
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -4062,6 +4093,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5135,6 +5171,14 @@ snapshots:
   '@mermaid-js/parser@1.0.1':
     dependencies:
       langium: 4.2.1
+
+  '@mtosity/design-system@0.1.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      framer-motion: 12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-icons: 5.6.0(react@19.0.0)
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -7532,6 +7576,15 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
+  framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -8550,6 +8603,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
   ms@2.1.3: {}
 
   nano-css@5.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
@@ -8887,6 +8946,10 @@ snapshots:
       resize-observer-polyfill: 1.5.1
 
   react-hook-form@7.54.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
+  react-icons@5.6.0(react@19.0.0):
     dependencies:
       react: 19.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^3.9.1
         version: 3.9.1(react-hook-form@7.54.0(react@19.0.0))
       '@mtosity/design-system':
-        specifier: 0.2.0
-        version: 0.2.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.3.0
+        version: 0.3.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.1
         version: 1.2.1(@types/react-dom@18.3.2)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -752,8 +752,8 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@mtosity/design-system@0.2.0':
-    resolution: {integrity: sha512-eul+ce0aRuvM0LZWFOUI3nbekQEUEJJcRNYs9pIj1QXyuS8C+LuL5xUd7FBNvVRKaaBVW7aN9OEGl0q2pPCYaw==, tarball: https://npm.pkg.github.com/download/@mtosity/design-system/0.2.0/f54745061e52d9ca3b51068cb97bcf015b4a1a61}
+  '@mtosity/design-system@0.3.0':
+    resolution: {integrity: sha512-5O9v/cZ6WDu06VRtmRFqszULNIZQDaIHvevylnj+WyoA4XBpHs9nxRsroF/mQL8YKwqLm7vff8tw/o5HGQ15Yg==, tarball: https://npm.pkg.github.com/download/@mtosity/design-system/0.3.0/faa53e16349804f97502f3cabb015a24f06f9b67}
     peerDependencies:
       framer-motion: ^12.0.0
       next: '>=15'
@@ -5172,7 +5172,7 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@mtosity/design-system@0.2.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@mtosity/design-system@0.3.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       framer-motion: 12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next: 15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^3.9.1
         version: 3.9.1(react-hook-form@7.54.0(react@19.0.0))
       '@mtosity/design-system':
-        specifier: 0.1.0
-        version: 0.1.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.2.0
+        version: 0.2.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.1
         version: 1.2.1(@types/react-dom@18.3.2)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -752,8 +752,8 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@mtosity/design-system@0.1.0':
-    resolution: {integrity: sha512-IXgLC3DUhjm/JC2Hwl+4/I6bCOw69k4nUt7gJfW/Q7MbOCy//WYI6PkJ+vDdxgl5pU3RfS8yqVYVT/VeSmz7Fw==, tarball: https://npm.pkg.github.com/download/@mtosity/design-system/0.1.0/1239a476f672f8c0d84bf4a5dee67a57942b109c}
+  '@mtosity/design-system@0.2.0':
+    resolution: {integrity: sha512-eul+ce0aRuvM0LZWFOUI3nbekQEUEJJcRNYs9pIj1QXyuS8C+LuL5xUd7FBNvVRKaaBVW7aN9OEGl0q2pPCYaw==, tarball: https://npm.pkg.github.com/download/@mtosity/design-system/0.2.0/f54745061e52d9ca3b51068cb97bcf015b4a1a61}
     peerDependencies:
       framer-motion: ^12.0.0
       next: '>=15'
@@ -5172,7 +5172,7 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@mtosity/design-system@0.1.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@mtosity/design-system@0.2.0(framer-motion@12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       framer-motion: 12.40.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next: 15.5.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)

--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -108,7 +108,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <main className="min-h-screen bg-background text-white">
+      <main className="min-h-screen bg-background text-foreground">
         {/* Hero Image */}
         <div className="relative h-64 w-full md:h-80 lg:h-96">
           <Image
@@ -120,13 +120,13 @@ export default async function BlogPage({ params }: BlogPageProps) {
             sizes="100vw"
           />
           <div className="absolute inset-0 bg-linear-to-t from-background via-background/40 to-transparent" />
-          <span className="absolute bottom-3 right-4 text-xs text-white/40">
+          <span className="absolute bottom-3 right-4 text-xs text-foreground/40">
             Photo via Unsplash
           </span>
         </div>
 
         {/* Article Header */}
-        <header className="border-b border-white/10 px-4 py-12 md:px-8 md:py-16">
+        <header className="border-b border-border px-4 py-12 md:px-8 md:py-16">
           <div className="mx-auto max-w-4xl">
             {/* Tags */}
             <div className="mb-6 flex flex-wrap gap-2">
@@ -134,7 +134,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
                 <Badge
                   key={tag}
                   variant="secondary"
-                  className="bg-purple-500/20 text-purple-300"
+                  className="bg-primary/20 text-primary"
                 >
                   {tag}
                 </Badge>
@@ -147,10 +147,10 @@ export default async function BlogPage({ params }: BlogPageProps) {
             </h1>
 
             {/* Excerpt */}
-            <p className="mt-6 text-lg text-gray-400">{frontmatter.excerpt}</p>
+            <p className="mt-6 text-lg text-muted-foreground">{frontmatter.excerpt}</p>
 
             {/* Meta */}
-            <div className="mt-8 flex flex-wrap items-center gap-6 text-sm text-gray-500">
+            <div className="mt-8 flex flex-wrap items-center gap-6 text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
                 <time dateTime={frontmatter.publishedAt}>
@@ -167,21 +167,21 @@ export default async function BlogPage({ params }: BlogPageProps) {
 
         {/* Article Content */}
         <article className="px-4 py-12 md:px-8">
-          <div className="prose prose-purple prose-invert mx-auto max-w-4xl prose-headings:text-white prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl prose-p:text-gray-300 prose-a:text-purple-400 prose-a:no-underline prose-a:hover:text-purple-300 prose-blockquote:border-purple-500 prose-blockquote:text-gray-400 prose-strong:text-white prose-code:text-purple-300 prose-pre:border prose-pre:border-white/10 prose-pre:bg-white/5 prose-li:text-gray-300 prose-table:text-gray-300 prose-th:border-white/10 prose-th:text-white prose-td:border-white/10">
+          <div className="prose prose-purple prose-invert mx-auto max-w-4xl prose-headings:text-foreground prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl prose-p:text-muted-foreground prose-a:text-primary prose-a:no-underline prose-a:hover:text-primary prose-blockquote:border-primary prose-blockquote:text-muted-foreground prose-strong:text-foreground prose-code:text-primary prose-pre:border prose-pre:border-border prose-pre:bg-foreground/5 prose-li:text-muted-foreground prose-table:text-muted-foreground prose-th:border-border prose-th:text-foreground prose-td:border-border">
             <BlogContent content={content} />
           </div>
         </article>
 
         {/* Related Posts / CTA */}
-        <section className="border-t border-white/10 px-4 py-12 md:px-8">
+        <section className="border-t border-border px-4 py-12 md:px-8">
           <div className="mx-auto max-w-4xl text-center">
             <h2 className="text-2xl font-bold">Continue Learning</h2>
-            <p className="mt-2 text-gray-400">
+            <p className="mt-2 text-muted-foreground">
               Explore more articles to improve your investment knowledge.
             </p>
             <Link
               href="/blogs"
-              className="mt-6 inline-flex items-center gap-2 rounded-lg bg-purple-500 px-6 py-3 font-medium text-white transition-colors hover:bg-purple-600"
+              className="mt-6 inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               View All Posts
             </Link>

--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -108,7 +108,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <main className="min-h-screen bg-[#15162c] text-white">
+      <main className="min-h-screen bg-background text-white">
         {/* Hero Image */}
         <div className="relative h-64 w-full md:h-80 lg:h-96">
           <Image
@@ -119,7 +119,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
             className="object-cover"
             sizes="100vw"
           />
-          <div className="absolute inset-0 bg-linear-to-t from-[#15162c] via-[#15162c]/40 to-transparent" />
+          <div className="absolute inset-0 bg-linear-to-t from-background via-background/40 to-transparent" />
           <span className="absolute bottom-3 right-4 text-xs text-white/40">
             Photo via Unsplash
           </span>

--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -134,7 +134,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
                 <Badge
                   key={tag}
                   variant="secondary"
-                  className="bg-primary/20 text-primary"
+                  className="bg-primary/20 text-foreground"
                 >
                   {tag}
                 </Badge>
@@ -167,7 +167,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
 
         {/* Article Content */}
         <article className="px-4 py-12 md:px-8">
-          <div className="prose prose-purple prose-invert mx-auto max-w-4xl prose-headings:text-foreground prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl prose-p:text-muted-foreground prose-a:text-primary prose-a:no-underline prose-a:hover:text-primary prose-blockquote:border-primary prose-blockquote:text-muted-foreground prose-strong:text-foreground prose-code:text-primary prose-pre:border prose-pre:border-border prose-pre:bg-foreground/5 prose-li:text-muted-foreground prose-table:text-muted-foreground prose-th:border-border prose-th:text-foreground prose-td:border-border">
+          <div className="prose  dark:prose-invert mx-auto max-w-4xl prose-headings:text-foreground prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl prose-p:text-muted-foreground prose-a:text-foreground prose-a:no-underline prose-a:hover:text-foreground prose-blockquote:border-primary prose-blockquote:text-muted-foreground prose-strong:text-foreground prose-code:text-foreground prose-pre:border prose-pre:border-border prose-pre:bg-foreground/5 prose-li:text-muted-foreground prose-table:text-muted-foreground prose-th:border-border prose-th:text-foreground prose-td:border-border">
             <BlogContent content={content} />
           </div>
         </article>

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -5,7 +5,7 @@ import { StockComparison } from "~/components/features/stock-comparison";
 
 export default function ComparePage() {
   return (
-    <main className="min-h-screen bg-[#15162c] text-white">
+    <main className="min-h-screen bg-background text-white">
       <Suspense
         fallback={
           <div className="flex items-center justify-center py-32">

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -5,11 +5,11 @@ import { StockComparison } from "~/components/features/stock-comparison";
 
 export default function ComparePage() {
   return (
-    <main className="min-h-screen bg-background text-white">
+    <main className="min-h-screen bg-background text-foreground">
       <Suspense
         fallback={
           <div className="flex items-center justify-center py-32">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-purple-400 border-t-transparent" />
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
           </div>
         }
       >

--- a/src/app/earnings/page.tsx
+++ b/src/app/earnings/page.tsx
@@ -7,12 +7,12 @@ export default function EarningsPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center bg-background text-white">
+        <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
           Loading...
         </div>
       }
     >
-      <main className="min-h-screen bg-background text-white">
+      <main className="min-h-screen bg-background text-foreground">
         <div className="px-4 pt-4">
           <div className="mb-6">
             <h1 className="text-3xl font-bold">Earnings Calendar</h1>

--- a/src/app/earnings/page.tsx
+++ b/src/app/earnings/page.tsx
@@ -7,12 +7,12 @@ export default function EarningsPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center bg-[#15162c] text-white">
+        <div className="flex min-h-screen items-center justify-center bg-background text-white">
           Loading...
         </div>
       }
     >
-      <main className="min-h-screen bg-[#15162c] text-white">
+      <main className="min-h-screen bg-background text-white">
         <div className="px-4 pt-4">
           <div className="mb-6">
             <h1 className="text-3xl font-bold">Earnings Calendar</h1>

--- a/src/app/influencers/page.tsx
+++ b/src/app/influencers/page.tsx
@@ -15,12 +15,12 @@ function LoadingState() {
   return (
     <div className="grid gap-4 lg:grid-cols-3">
       <div className="space-y-4 lg:col-span-2">
-        <Skeleton className="h-72 w-full rounded-xl bg-white/5" />
-        <Skeleton className="h-64 w-full rounded-xl bg-white/5" />
+        <Skeleton className="h-72 w-full rounded-xl bg-foreground/5" />
+        <Skeleton className="h-64 w-full rounded-xl bg-foreground/5" />
       </div>
       <div className="space-y-4">
-        <Skeleton className="h-48 w-full rounded-xl bg-white/5" />
-        <Skeleton className="h-64 w-full rounded-xl bg-white/5" />
+        <Skeleton className="h-48 w-full rounded-xl bg-foreground/5" />
+        <Skeleton className="h-64 w-full rounded-xl bg-foreground/5" />
       </div>
     </div>
   );
@@ -28,12 +28,12 @@ function LoadingState() {
 
 function EmptyState() {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardContent className="flex flex-col items-center gap-3 py-16 text-center">
         <Inbox className="h-10 w-10 text-gray-600" />
         <h2 className="text-lg font-semibold">No influencer data yet</h2>
-        <p className="max-w-md text-sm text-gray-400">
-          Run the <code className="rounded bg-black/30 px-1.5 py-0.5 text-purple-200">
+        <p className="max-w-md text-sm text-muted-foreground">
+          Run the <code className="rounded bg-black/30 px-1.5 py-0.5 text-primary">
             thestockie-influencer
           </code>{" "}
           job to scan tracked creators, transcribe their latest videos, and
@@ -66,20 +66,20 @@ export default function InfluencersPage() {
     (videosQ.data?.length ?? 0) > 0;
 
   return (
-    <div className="min-h-screen bg-background pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-foreground">
       <div className="mx-auto max-w-6xl px-4 pt-6">
         <header className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="flex items-center gap-2 text-3xl font-bold">
-              <Radar className="h-7 w-7 text-purple-400" /> Influencer Radar
+              <Radar className="h-7 w-7 text-primary" /> Influencer Radar
             </h1>
-            <p className="mt-1 text-sm text-gray-400">
+            <p className="mt-1 text-sm text-muted-foreground">
               What YouTube stock creators are buying, selling, and saying —
               aggregated daily.
             </p>
           </div>
           {lastUpdated && (
-            <div className="flex items-center gap-1.5 text-xs text-gray-500">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <RefreshCw className="h-3.5 w-3.5" /> Updated{" "}
               {formatRelative(lastUpdated)}
             </div>

--- a/src/app/influencers/page.tsx
+++ b/src/app/influencers/page.tsx
@@ -66,7 +66,7 @@ export default function InfluencersPage() {
     (videosQ.data?.length ?? 0) > 0;
 
   return (
-    <div className="min-h-screen bg-[#15162c] pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-white">
       <div className="mx-auto max-w-6xl px-4 pt-6">
         <header className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>

--- a/src/app/influencers/page.tsx
+++ b/src/app/influencers/page.tsx
@@ -33,7 +33,7 @@ function EmptyState() {
         <Inbox className="h-10 w-10 text-gray-600" />
         <h2 className="text-lg font-semibold">No influencer data yet</h2>
         <p className="max-w-md text-sm text-muted-foreground">
-          Run the <code className="rounded bg-black/30 px-1.5 py-0.5 text-primary">
+          Run the <code className="rounded bg-black/30 px-1.5 py-0.5 text-foreground">
             thestockie-influencer
           </code>{" "}
           job to scan tracked creators, transcribe their latest videos, and
@@ -71,7 +71,7 @@ export default function InfluencersPage() {
         <header className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="flex items-center gap-2 text-3xl font-bold">
-              <Radar className="h-7 w-7 text-primary" /> Influencer Radar
+              <Radar className="h-7 w-7 text-foreground" /> Influencer Radar
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
               What YouTube stock creators are buying, selling, and saying —

--- a/src/app/influencers/page.tsx
+++ b/src/app/influencers/page.tsx
@@ -33,7 +33,7 @@ function EmptyState() {
         <Inbox className="h-10 w-10 text-gray-600" />
         <h2 className="text-lg font-semibold">No influencer data yet</h2>
         <p className="max-w-md text-sm text-muted-foreground">
-          Run the <code className="rounded bg-black/30 px-1.5 py-0.5 text-foreground">
+          Run the <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">
             thestockie-influencer
           </code>{" "}
           job to scan tracked creators, transcribe their latest videos, and

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,34 @@
 import "~/styles/globals.css";
 
-import { GeistSans } from "geist/font/sans";
+import { Inter, Crimson_Text, Lora } from "next/font/google";
 import { type Metadata } from "next";
 import { Analytics } from "@vercel/analytics/next";
 
 import { TRPCReactProvider } from "~/trpc/react";
 import { ConvexClientProvider } from "~/components/ConvexClientProvider";
 import { SessionProvider } from "next-auth/react";
+import { ThemeProvider } from "~/components/theme-provider";
 import { Navbar } from "~/components/features/navbar";
 import { auth } from "~/server/auth";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const crimson = Crimson_Text({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  variable: "--font-crimson-text",
+  display: "swap",
+});
+
+const lora = Lora({
+  subsets: ["latin"],
+  variable: "--font-lora",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "thestockie - @mtosity",
@@ -42,15 +62,20 @@ export default async function RootLayout({
   const session = await auth();
 
   return (
-    <html lang="en" className={`${GeistSans.variable}`}>
+    <html
+      lang="en"
+      className={`${inter.variable} ${crimson.variable} ${lora.variable}`}
+      suppressHydrationWarning
+    >
       <body>
-        <ConvexClientProvider>
-          <TRPCReactProvider>
-            <SessionProvider session={session}>
-              <Navbar />
-              {children}
-              <footer>
-                <div className="flex h-16 items-center justify-center gap-8 bg-[#15162c] text-white">
+        <ThemeProvider>
+          <ConvexClientProvider>
+            <TRPCReactProvider>
+              <SessionProvider session={session}>
+                <Navbar />
+                {children}
+                <footer>
+                  <div className="flex h-16 items-center justify-center gap-8 border-t border-border bg-card text-foreground">
                   <p className="text-sm">&copy;{new Date().getFullYear()}</p>
                   <a
                     href="https://mtosity.com"
@@ -70,9 +95,10 @@ export default async function RootLayout({
                   </a>
                 </div>
               </footer>
-            </SessionProvider>
-          </TRPCReactProvider>
-        </ConvexClientProvider>
+              </SessionProvider>
+            </TRPCReactProvider>
+          </ConvexClientProvider>
+        </ThemeProvider>
         <Analytics />
       </body>
     </html>

--- a/src/app/macro/page.tsx
+++ b/src/app/macro/page.tsx
@@ -7,12 +7,12 @@ export default function MacroPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center bg-[#15162c] text-white">
+        <div className="flex min-h-screen items-center justify-center bg-background text-white">
           Loading...
         </div>
       }
     >
-      <main className="min-h-screen bg-[#15162c] text-white">
+      <main className="min-h-screen bg-background text-white">
         <div className="px-4 pt-4">
           <div className="mb-2">
             <h1 className="text-3xl font-bold">Macro Overview</h1>

--- a/src/app/macro/page.tsx
+++ b/src/app/macro/page.tsx
@@ -7,16 +7,16 @@ export default function MacroPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center bg-background text-white">
+        <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
           Loading...
         </div>
       }
     >
-      <main className="min-h-screen bg-background text-white">
+      <main className="min-h-screen bg-background text-foreground">
         <div className="px-4 pt-4">
           <div className="mb-2">
             <h1 className="text-3xl font-bold">Macro Overview</h1>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-muted-foreground">
               Global markets, volatility, rates, and economic indicators
             </p>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { HydrateClient } from "~/trpc/server";
 export default async function Home() {
   return (
     <HydrateClient>
-      <main className="min-h-screen bg-background text-white">
+      <main className="min-h-screen bg-background text-foreground">
         <Grid />
       </main>
     </HydrateClient>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { HydrateClient } from "~/trpc/server";
 export default async function Home() {
   return (
     <HydrateClient>
-      <main className="min-h-screen bg-[#15162c] text-white">
+      <main className="min-h-screen bg-background text-white">
         <Grid />
       </main>
     </HydrateClient>

--- a/src/app/screener/page.tsx
+++ b/src/app/screener/page.tsx
@@ -153,7 +153,7 @@ function ScreenerContent() {
     };
 
   return (
-    <div className="min-h-screen bg-background pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-foreground">
       <div className="px-4 pt-4">
         <div className="mb-6">
           <h1 className="text-3xl font-bold">Screener</h1>

--- a/src/app/screener/page.tsx
+++ b/src/app/screener/page.tsx
@@ -153,7 +153,7 @@ function ScreenerContent() {
     };
 
   return (
-    <div className="min-h-screen bg-[#15162c] pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-white">
       <div className="px-4 pt-4">
         <div className="mb-6">
           <h1 className="text-3xl font-bold">Screener</h1>

--- a/src/components/features/analyst-ratings.tsx
+++ b/src/components/features/analyst-ratings.tsx
@@ -74,7 +74,7 @@ function isTier1(firm: string) {
 function gradeColor(grade: string): string {
   const g = grade.toLowerCase();
   if (g.includes("strong buy") || g.includes("conviction"))
-    return "text-green-400";
+    return "text-green-700 dark:text-green-400";
   if (
     g.includes("buy") ||
     g.includes("outperform") ||
@@ -82,7 +82,7 @@ function gradeColor(grade: string): string {
     g.includes("positive") ||
     g.includes("accumulate")
   )
-    return "text-green-300";
+    return "text-green-700 dark:text-green-400";
   if (
     g.includes("hold") ||
     g.includes("neutral") ||
@@ -92,7 +92,7 @@ function gradeColor(grade: string): string {
     g.includes("sector perform") ||
     g.includes("in-line")
   )
-    return "text-yellow-300";
+    return "text-yellow-700 dark:text-yellow-400";
   if (
     g.includes("sell") ||
     g.includes("underperform") ||
@@ -100,7 +100,7 @@ function gradeColor(grade: string): string {
     g.includes("negative") ||
     g.includes("reduce")
   )
-    return "text-red-400";
+    return "text-red-700 dark:text-red-400";
   return "text-muted-foreground";
 }
 
@@ -249,44 +249,44 @@ export const AnalystRatings = () => {
       label: "Strong Buy",
       count: strongBuy,
       color: "bg-green-500",
-      textColor: "text-green-400",
+      textColor: "text-green-700 dark:text-green-400",
     },
     {
       label: "Buy",
       count: buy,
       color: "bg-green-400",
-      textColor: "text-green-300",
+      textColor: "text-green-700 dark:text-green-400",
     },
     {
       label: "Hold",
       count: hold,
       color: "bg-yellow-400",
-      textColor: "text-yellow-300",
+      textColor: "text-yellow-700 dark:text-yellow-400",
     },
     {
       label: "Sell",
       count: sell,
       color: "bg-red-400",
-      textColor: "text-red-300",
+      textColor: "text-red-700 dark:text-red-400",
     },
     {
       label: "Strong Sell",
       count: strongSell,
       color: "bg-red-500",
-      textColor: "text-red-400",
+      textColor: "text-red-700 dark:text-red-400",
     },
   ];
 
   const bullish = strongBuy + buy;
   const bearish = sell + strongSell;
   let consensus = "Hold";
-  let consensusColor = "text-yellow-400";
+  let consensusColor = "text-yellow-700 dark:text-yellow-400";
   if (bullish > bearish + hold) {
     consensus = "Buy";
-    consensusColor = "text-green-400";
+    consensusColor = "text-green-700 dark:text-green-400";
   } else if (bearish > bullish + hold) {
     consensus = "Sell";
-    consensusColor = "text-red-400";
+    consensusColor = "text-red-700 dark:text-red-400";
   }
 
   // Sort grades: tier1 first, then by date desc
@@ -367,10 +367,10 @@ export const AnalystRatings = () => {
                   {/* Direction icon */}
                   <div className="shrink-0">
                     {direction === "upgrade" && (
-                      <ArrowUp className="h-3 w-3 text-green-400" />
+                      <ArrowUp className="h-3 w-3 text-green-700 dark:text-green-400" />
                     )}
                     {direction === "downgrade" && (
-                      <ArrowDown className="h-3 w-3 text-red-400" />
+                      <ArrowDown className="h-3 w-3 text-red-700 dark:text-red-400" />
                     )}
                     {direction === "same" && (
                       <Minus className="h-3 w-3 text-muted-foreground" />

--- a/src/components/features/analyst-ratings.tsx
+++ b/src/components/features/analyst-ratings.tsx
@@ -101,7 +101,7 @@ function gradeColor(grade: string): string {
     g.includes("reduce")
   )
     return "text-red-400";
-  return "text-gray-300";
+  return "text-muted-foreground";
 }
 
 function gradeBgColor(grade: string): string {
@@ -134,7 +134,7 @@ function gradeBgColor(grade: string): string {
     g.includes("reduce")
   )
     return "bg-red-500/10";
-  return "bg-white/5";
+  return "bg-foreground/5";
 }
 
 function getDirection(
@@ -199,7 +199,7 @@ export const AnalystRatings = () => {
   if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ThumbsUp className="h-4 w-4 text-blue-400" />
           <span className="text-sm font-semibold text-gray-200">
             Analyst Ratings
@@ -208,8 +208,8 @@ export const AnalystRatings = () => {
         <div className="flex-1 space-y-3 p-4">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="flex animate-pulse items-center gap-3">
-              <div className="h-3 w-24 rounded bg-white/10" />
-              <div className="ml-auto h-3 w-14 rounded bg-white/10" />
+              <div className="h-3 w-24 rounded bg-foreground/10" />
+              <div className="ml-auto h-3 w-14 rounded bg-foreground/10" />
             </div>
           ))}
         </div>
@@ -223,13 +223,13 @@ export const AnalystRatings = () => {
   if (!latest && !hasGrades) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ThumbsUp className="h-4 w-4 text-blue-400" />
           <span className="text-sm font-semibold text-gray-200">
             Analyst Ratings
           </span>
         </div>
-        <div className="flex flex-1 items-center justify-center text-sm text-gray-500">
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No analyst data
         </div>
       </div>
@@ -310,7 +310,7 @@ export const AnalystRatings = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <div className="flex items-center gap-2">
           <ThumbsUp className="h-4 w-4 text-blue-400" />
           <span className="text-sm font-semibold text-gray-200">
@@ -339,7 +339,7 @@ export const AnalystRatings = () => {
                   ),
               )}
             </div>
-            <div className="mt-1.5 flex justify-between text-[10px] text-gray-500">
+            <div className="mt-1.5 flex justify-between text-[10px] text-muted-foreground">
               <span>{bullish} Buy</span>
               <span>{hold} Hold</span>
               <span>{bearish} Sell</span>
@@ -350,7 +350,7 @@ export const AnalystRatings = () => {
         {/* Per-firm grades */}
         {displayGrades.length > 0 && (
           <div className="mt-2">
-            <div className="border-b border-white/5 px-4 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+            <div className="border-b border-border px-4 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
               Firm Ratings (latest per firm)
             </div>
             {displayGrades.map((grade, idx) => {
@@ -362,7 +362,7 @@ export const AnalystRatings = () => {
               return (
                 <div
                   key={`${grade.gradingCompany}-${idx}`}
-                  className="flex items-center gap-2 border-b border-white/5 px-3 py-1.5 transition-colors hover:bg-white/5"
+                  className="flex items-center gap-2 border-b border-border px-3 py-1.5 transition-colors hover:bg-accent"
                 >
                   {/* Direction icon */}
                   <div className="shrink-0">
@@ -373,7 +373,7 @@ export const AnalystRatings = () => {
                       <ArrowDown className="h-3 w-3 text-red-400" />
                     )}
                     {direction === "same" && (
-                      <Minus className="h-3 w-3 text-gray-500" />
+                      <Minus className="h-3 w-3 text-muted-foreground" />
                     )}
                   </div>
 
@@ -381,7 +381,7 @@ export const AnalystRatings = () => {
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1">
                       <span
-                        className={`truncate text-xs font-medium ${tier1 ? "text-gray-100" : "text-gray-400"}`}
+                        className={`truncate text-xs font-medium ${tier1 ? "text-gray-100" : "text-muted-foreground"}`}
                       >
                         {grade.gradingCompany}
                       </span>
@@ -391,7 +391,7 @@ export const AnalystRatings = () => {
                         </span>
                       )}
                     </div>
-                    <div className="text-[10px] text-gray-500">
+                    <div className="text-[10px] text-muted-foreground">
                       {format(new Date(grade.date), "MMM d, yyyy")}
                     </div>
                   </div>
@@ -410,7 +410,7 @@ export const AnalystRatings = () => {
             {latestPerFirm.length > 10 && (
               <button
                 onClick={() => setShowAll(!showAll)}
-                className="flex w-full items-center justify-center gap-1 py-2 text-[11px] text-purple-400 transition-colors hover:text-purple-300"
+                className="flex w-full items-center justify-center gap-1 py-2 text-[11px] text-primary transition-colors hover:text-primary"
               >
                 {showAll ? (
                   <>

--- a/src/components/features/analyst-ratings.tsx
+++ b/src/components/features/analyst-ratings.tsx
@@ -201,7 +201,7 @@ export const AnalystRatings = () => {
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ThumbsUp className="h-4 w-4 text-blue-400" />
-          <span className="text-sm font-semibold text-gray-200">
+          <span className="text-sm font-semibold text-muted-foreground">
             Analyst Ratings
           </span>
         </div>
@@ -225,7 +225,7 @@ export const AnalystRatings = () => {
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ThumbsUp className="h-4 w-4 text-blue-400" />
-          <span className="text-sm font-semibold text-gray-200">
+          <span className="text-sm font-semibold text-muted-foreground">
             Analyst Ratings
           </span>
         </div>
@@ -313,7 +313,7 @@ export const AnalystRatings = () => {
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <div className="flex items-center gap-2">
           <ThumbsUp className="h-4 w-4 text-blue-400" />
-          <span className="text-sm font-semibold text-gray-200">
+          <span className="text-sm font-semibold text-muted-foreground">
             Analyst Ratings
           </span>
         </div>
@@ -381,7 +381,7 @@ export const AnalystRatings = () => {
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1">
                       <span
-                        className={`truncate text-xs font-medium ${tier1 ? "text-gray-100" : "text-muted-foreground"}`}
+                        className={`truncate text-xs font-medium ${tier1 ? "text-muted-foreground" : "text-muted-foreground"}`}
                       >
                         {grade.gradingCompany}
                       </span>
@@ -410,7 +410,7 @@ export const AnalystRatings = () => {
             {latestPerFirm.length > 10 && (
               <button
                 onClick={() => setShowAll(!showAll)}
-                className="flex w-full items-center justify-center gap-1 py-2 text-[11px] text-primary transition-colors hover:text-primary"
+                className="flex w-full items-center justify-center gap-1 py-2 text-[11px] text-foreground transition-colors hover:text-foreground"
               >
                 {showAll ? (
                   <>

--- a/src/components/features/analyst-ratings.tsx
+++ b/src/components/features/analyst-ratings.tsx
@@ -74,7 +74,7 @@ function isTier1(firm: string) {
 function gradeColor(grade: string): string {
   const g = grade.toLowerCase();
   if (g.includes("strong buy") || g.includes("conviction"))
-    return "text-green-700 dark:text-green-400";
+    return "text-positive";
   if (
     g.includes("buy") ||
     g.includes("outperform") ||
@@ -82,7 +82,7 @@ function gradeColor(grade: string): string {
     g.includes("positive") ||
     g.includes("accumulate")
   )
-    return "text-green-700 dark:text-green-400";
+    return "text-positive";
   if (
     g.includes("hold") ||
     g.includes("neutral") ||
@@ -92,7 +92,7 @@ function gradeColor(grade: string): string {
     g.includes("sector perform") ||
     g.includes("in-line")
   )
-    return "text-yellow-700 dark:text-yellow-400";
+    return "text-warning";
   if (
     g.includes("sell") ||
     g.includes("underperform") ||
@@ -100,14 +100,14 @@ function gradeColor(grade: string): string {
     g.includes("negative") ||
     g.includes("reduce")
   )
-    return "text-red-700 dark:text-red-400";
+    return "text-negative";
   return "text-muted-foreground";
 }
 
 function gradeBgColor(grade: string): string {
   const g = grade.toLowerCase();
   if (g.includes("strong buy") || g.includes("conviction"))
-    return "bg-green-500/20";
+    return "bg-positive-surface";
   if (
     g.includes("buy") ||
     g.includes("outperform") ||
@@ -115,7 +115,7 @@ function gradeBgColor(grade: string): string {
     g.includes("positive") ||
     g.includes("accumulate")
   )
-    return "bg-green-500/10";
+    return "bg-positive-surface";
   if (
     g.includes("hold") ||
     g.includes("neutral") ||
@@ -125,7 +125,7 @@ function gradeBgColor(grade: string): string {
     g.includes("sector perform") ||
     g.includes("in-line")
   )
-    return "bg-yellow-500/10";
+    return "bg-warning-surface";
   if (
     g.includes("sell") ||
     g.includes("underperform") ||
@@ -133,7 +133,7 @@ function gradeBgColor(grade: string): string {
     g.includes("negative") ||
     g.includes("reduce")
   )
-    return "bg-red-500/10";
+    return "bg-negative-surface";
   return "bg-foreground/5";
 }
 
@@ -249,44 +249,44 @@ export const AnalystRatings = () => {
       label: "Strong Buy",
       count: strongBuy,
       color: "bg-green-500",
-      textColor: "text-green-700 dark:text-green-400",
+      textColor: "text-positive",
     },
     {
       label: "Buy",
       count: buy,
       color: "bg-green-400",
-      textColor: "text-green-700 dark:text-green-400",
+      textColor: "text-positive",
     },
     {
       label: "Hold",
       count: hold,
       color: "bg-yellow-400",
-      textColor: "text-yellow-700 dark:text-yellow-400",
+      textColor: "text-warning",
     },
     {
       label: "Sell",
       count: sell,
       color: "bg-red-400",
-      textColor: "text-red-700 dark:text-red-400",
+      textColor: "text-negative",
     },
     {
       label: "Strong Sell",
       count: strongSell,
       color: "bg-red-500",
-      textColor: "text-red-700 dark:text-red-400",
+      textColor: "text-negative",
     },
   ];
 
   const bullish = strongBuy + buy;
   const bearish = sell + strongSell;
   let consensus = "Hold";
-  let consensusColor = "text-yellow-700 dark:text-yellow-400";
+  let consensusColor = "text-warning";
   if (bullish > bearish + hold) {
     consensus = "Buy";
-    consensusColor = "text-green-700 dark:text-green-400";
+    consensusColor = "text-positive";
   } else if (bearish > bullish + hold) {
     consensus = "Sell";
-    consensusColor = "text-red-700 dark:text-red-400";
+    consensusColor = "text-negative";
   }
 
   // Sort grades: tier1 first, then by date desc
@@ -367,10 +367,10 @@ export const AnalystRatings = () => {
                   {/* Direction icon */}
                   <div className="shrink-0">
                     {direction === "upgrade" && (
-                      <ArrowUp className="h-3 w-3 text-green-700 dark:text-green-400" />
+                      <ArrowUp className="h-3 w-3 text-positive" />
                     )}
                     {direction === "downgrade" && (
-                      <ArrowDown className="h-3 w-3 text-red-700 dark:text-red-400" />
+                      <ArrowDown className="h-3 w-3 text-negative" />
                     )}
                     {direction === "same" && (
                       <Minus className="h-3 w-3 text-muted-foreground" />

--- a/src/components/features/balance_growth.tsx
+++ b/src/components/features/balance_growth.tsx
@@ -23,7 +23,7 @@ interface CustomTooltipProps {
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded border border-[#424975] bg-[#151624] p-3 text-sm shadow-lg">
+    <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
       <p className="mb-1 font-medium text-gray-200">{`Period: ${label}`}</p>
       {payload.map((pld) => (
         <p key={pld.name} style={{ color: pld.fill ?? pld.stroke }}>
@@ -58,7 +58,7 @@ export const BalanceGrowth = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center">
           <div className="mb-4 h-6 w-48 rounded bg-gray-700"></div>
           <div className="h-[400px] w-full rounded bg-gray-700"></div>

--- a/src/components/features/balance_growth.tsx
+++ b/src/components/features/balance_growth.tsx
@@ -60,8 +60,8 @@ export const BalanceGrowth = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center">
-          <div className="mb-4 h-6 w-48 rounded bg-gray-700"></div>
-          <div className="h-[400px] w-full rounded bg-gray-700"></div>
+          <div className="mb-4 h-6 w-48 rounded bg-muted"></div>
+          <div className="h-[400px] w-full rounded bg-muted"></div>
         </div>
       </div>
     );

--- a/src/components/features/balance_growth.tsx
+++ b/src/components/features/balance_growth.tsx
@@ -24,7 +24,7 @@ const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
-      <p className="mb-1 font-medium text-gray-200">{`Period: ${label}`}</p>
+      <p className="mb-1 font-medium text-muted-foreground">{`Period: ${label}`}</p>
       {payload.map((pld) => (
         <p key={pld.name} style={{ color: pld.fill ?? pld.stroke }}>
           {`${pld.name}: ${formatLargeNumber(pld.value)}`}
@@ -69,7 +69,7 @@ export const BalanceGrowth = () => {
 
   return (
     <div>
-      <h2 className="mt-2 text-center text-xl font-semibold text-gray-200">
+      <h2 className="mt-2 text-center text-xl font-semibold text-muted-foreground">
         Balance Sheet
       </h2>
       <ResponsiveContainer width="100%" height={500}>

--- a/src/components/features/blog-card.tsx
+++ b/src/components/features/blog-card.tsx
@@ -18,8 +18,8 @@ export function BlogCard({ blog, className }: BlogCardProps) {
     <Link href={`/blogs/${frontmatter.slug}`} className="group block">
       <Card
         className={cn(
-          "h-full overflow-hidden border-white/10 bg-white/5 transition-all duration-300",
-          "hover:border-white/20 hover:bg-white/10 hover:shadow-xl hover:shadow-purple-500/10",
+          "h-full overflow-hidden border-border bg-foreground/5 transition-all duration-300",
+          "hover:border-border hover:bg-accent hover:shadow-xl hover:shadow-primary/20",
           "hover:-translate-y-1",
           className
         )}
@@ -33,7 +33,7 @@ export function BlogCard({ blog, className }: BlogCardProps) {
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
           <div className="absolute inset-0 bg-linear-to-t from-black/60 to-transparent" />
-          <span className="absolute bottom-2 right-2 text-[10px] text-white/40">
+          <span className="absolute bottom-2 right-2 text-[10px] text-foreground/40">
             Unsplash
           </span>
         </div>
@@ -44,24 +44,24 @@ export function BlogCard({ blog, className }: BlogCardProps) {
               <Badge
                 key={tag}
                 variant="secondary"
-                className="bg-purple-500/20 text-purple-300 hover:bg-purple-500/30"
+                className="bg-primary/20 text-primary hover:bg-primary/30"
               >
                 {tag}
               </Badge>
             ))}
           </div>
-          <h3 className="line-clamp-2 text-lg font-semibold text-white transition-colors group-hover:text-purple-300">
+          <h3 className="line-clamp-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
             {frontmatter.title}
           </h3>
         </CardHeader>
 
         <CardContent>
-          <p className="line-clamp-3 text-sm text-gray-400">
+          <p className="line-clamp-3 text-sm text-muted-foreground">
             {frontmatter.excerpt}
           </p>
         </CardContent>
 
-        <CardFooter className="flex items-center gap-4 text-xs text-gray-500">
+        <CardFooter className="flex items-center gap-4 text-xs text-muted-foreground">
           <div className="flex items-center gap-1">
             <Calendar className="h-3.5 w-3.5" />
             <span>{formatBlogDate(frontmatter.publishedAt)}</span>

--- a/src/components/features/blog-card.tsx
+++ b/src/components/features/blog-card.tsx
@@ -44,13 +44,13 @@ export function BlogCard({ blog, className }: BlogCardProps) {
               <Badge
                 key={tag}
                 variant="secondary"
-                className="bg-primary/20 text-primary hover:bg-primary/30"
+                className="bg-primary/20 text-foreground hover:bg-primary/30"
               >
                 {tag}
               </Badge>
             ))}
           </div>
-          <h3 className="line-clamp-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
+          <h3 className="line-clamp-2 text-lg font-semibold text-foreground transition-colors group-hover:text-foreground">
             {frontmatter.title}
           </h3>
         </CardHeader>

--- a/src/components/features/blog-tag-filter.tsx
+++ b/src/components/features/blog-tag-filter.tsx
@@ -20,8 +20,8 @@ export function BlogTagFilter({
         className={cn(
           "rounded-full px-4 py-2 text-sm font-medium transition-all duration-200",
           selectedTag === null
-            ? "bg-purple-500 text-white shadow-lg shadow-purple-500/25"
-            : "bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white"
+            ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20"
+            : "bg-foreground/5 text-muted-foreground hover:bg-accent hover:text-foreground"
         )}
       >
         All
@@ -33,8 +33,8 @@ export function BlogTagFilter({
           className={cn(
             "rounded-full px-4 py-2 text-sm font-medium capitalize transition-all duration-200",
             selectedTag === tag
-              ? "bg-purple-500 text-white shadow-lg shadow-purple-500/25"
-              : "bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white"
+              ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20"
+              : "bg-foreground/5 text-muted-foreground hover:bg-accent hover:text-foreground"
           )}
         >
           {tag}

--- a/src/components/features/blogs-content.tsx
+++ b/src/components/features/blogs-content.tsx
@@ -19,7 +19,7 @@ export function BlogsContent({ blogs, tags }: BlogsContentProps) {
     : blogs;
 
   return (
-    <main className="min-h-screen bg-[#15162c] text-white">
+    <main className="min-h-screen bg-background text-white">
       {/* Hero Section */}
       <div className="relative overflow-hidden border-b border-white/10 px-4 py-16 md:px-8 md:py-24">
         <div className="absolute inset-0 bg-linear-to-br from-purple-500/10 via-transparent to-blue-500/10" />

--- a/src/components/features/blogs-content.tsx
+++ b/src/components/features/blogs-content.tsx
@@ -29,7 +29,7 @@ export function BlogsContent({ blogs, tags }: BlogsContentProps) {
         <div className="relative mx-auto max-w-7xl">
           <div className="flex items-center gap-3">
             <div className="rounded-xl bg-primary/20 p-3">
-              <BookOpen className="h-8 w-8 text-primary" />
+              <BookOpen className="h-8 w-8 text-foreground" />
             </div>
             <p className="max-w-2xl text-lg text-muted-foreground">
               Insights, guides, and analysis to help you make smarter investment
@@ -74,7 +74,7 @@ export function BlogsContent({ blogs, tags }: BlogsContentProps) {
             </p>
             <button
               onClick={() => setSelectedTag(null)}
-              className="mt-4 text-primary hover:text-primary"
+              className="mt-4 text-foreground hover:text-foreground"
             >
               Clear filter
             </button>

--- a/src/components/features/blogs-content.tsx
+++ b/src/components/features/blogs-content.tsx
@@ -19,19 +19,19 @@ export function BlogsContent({ blogs, tags }: BlogsContentProps) {
     : blogs;
 
   return (
-    <main className="min-h-screen bg-background text-white">
+    <main className="min-h-screen bg-background text-foreground">
       {/* Hero Section */}
-      <div className="relative overflow-hidden border-b border-white/10 px-4 py-16 md:px-8 md:py-24">
-        <div className="absolute inset-0 bg-linear-to-br from-purple-500/10 via-transparent to-blue-500/10" />
-        <div className="absolute -left-1/4 -top-1/2 h-96 w-96 rounded-full bg-purple-500/20 blur-3xl" />
+      <div className="relative overflow-hidden border-b border-border px-4 py-16 md:px-8 md:py-24">
+        <div className="absolute inset-0 bg-linear-to-br from-primary/10 via-transparent to-blue-500/10" />
+        <div className="absolute -left-1/4 -top-1/2 h-96 w-96 rounded-full bg-primary/20 blur-3xl" />
         <div className="absolute -bottom-1/2 -right-1/4 h-96 w-96 rounded-full bg-blue-500/20 blur-3xl" />
 
         <div className="relative mx-auto max-w-7xl">
           <div className="flex items-center gap-3">
-            <div className="rounded-xl bg-purple-500/20 p-3">
-              <BookOpen className="h-8 w-8 text-purple-400" />
+            <div className="rounded-xl bg-primary/20 p-3">
+              <BookOpen className="h-8 w-8 text-primary" />
             </div>
-            <p className="max-w-2xl text-lg text-gray-400">
+            <p className="max-w-2xl text-lg text-muted-foreground">
               Insights, guides, and analysis to help you make smarter investment
               decisions. Learn about fundamentals, market trends, and investment
               strategies.
@@ -44,7 +44,7 @@ export function BlogsContent({ blogs, tags }: BlogsContentProps) {
       <div className="mx-auto max-w-7xl px-4 py-12 md:px-8">
         {/* Tag Filter */}
         <div className="mb-8">
-          <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-gray-500">
+          <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
             Filter by topic
           </h2>
           <BlogTagFilter
@@ -63,18 +63,18 @@ export function BlogsContent({ blogs, tags }: BlogsContentProps) {
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div className="rounded-full bg-white/5 p-6">
+            <div className="rounded-full bg-foreground/5 p-6">
               <BookOpen className="h-12 w-12 text-gray-600" />
             </div>
-            <h3 className="mt-6 text-xl font-semibold text-gray-300">
+            <h3 className="mt-6 text-xl font-semibold text-muted-foreground">
               No posts found
             </h3>
-            <p className="mt-2 text-gray-500">
+            <p className="mt-2 text-muted-foreground">
               No blog posts match the selected filter.
             </p>
             <button
               onClick={() => setSelectedTag(null)}
-              className="mt-4 text-purple-400 hover:text-purple-300"
+              className="mt-4 text-primary hover:text-primary"
             >
               Clear filter
             </button>

--- a/src/components/features/cash-debt.tsx
+++ b/src/components/features/cash-debt.tsx
@@ -28,7 +28,7 @@ interface TooltipProps {
 const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded border border-[#424975] bg-[#151624] p-3 text-sm shadow-lg">
+    <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
       <p className="mb-1 font-medium text-gray-200">{formatQuarter(label ?? "")}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>
@@ -63,7 +63,7 @@ export const CashDebt = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
           <div className="h-6 w-48 rounded bg-gray-700" />
           <div className="h-[400px] w-full rounded bg-gray-700" />

--- a/src/components/features/cash-debt.tsx
+++ b/src/components/features/cash-debt.tsx
@@ -29,7 +29,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
-      <p className="mb-1 font-medium text-gray-200">{formatQuarter(label ?? "")}</p>
+      <p className="mb-1 font-medium text-muted-foreground">{formatQuarter(label ?? "")}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>
           {entry.name}: ${formatLargeNumber(entry.value)}
@@ -74,7 +74,7 @@ export const CashDebt = () => {
 
   return (
     <div className="w-full">
-      <h2 className="mt-2 text-center text-xl font-semibold text-gray-200">
+      <h2 className="mt-2 text-center text-xl font-semibold text-muted-foreground">
         Cash &amp; Debt
       </h2>
       <ResponsiveContainer width="100%" height={480}>

--- a/src/components/features/cash-debt.tsx
+++ b/src/components/features/cash-debt.tsx
@@ -65,8 +65,8 @@ export const CashDebt = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
-          <div className="h-6 w-48 rounded bg-gray-700" />
-          <div className="h-[400px] w-full rounded bg-gray-700" />
+          <div className="h-6 w-48 rounded bg-muted" />
+          <div className="h-[400px] w-full rounded bg-muted" />
         </div>
       </div>
     );

--- a/src/components/features/cash_growth.tsx
+++ b/src/components/features/cash_growth.tsx
@@ -137,8 +137,8 @@ export const CashGrowth = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center">
-          <div className="mb-4 h-6 w-48 rounded bg-gray-700"></div>
-          <div className="h-[400px] w-full rounded bg-gray-700"></div>
+          <div className="mb-4 h-6 w-48 rounded bg-muted"></div>
+          <div className="h-[400px] w-full rounded bg-muted"></div>
         </div>
       </div>
     );

--- a/src/components/features/cash_growth.tsx
+++ b/src/components/features/cash_growth.tsx
@@ -30,8 +30,8 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "quarterly"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       Quarterly
@@ -41,8 +41,8 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "ttm"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       TTM

--- a/src/components/features/cash_growth.tsx
+++ b/src/components/features/cash_growth.tsx
@@ -31,7 +31,7 @@ const PeriodToggle = ({
         "px-3 py-1 transition-colors",
         period === "quarterly"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       Quarterly
@@ -42,7 +42,7 @@ const PeriodToggle = ({
         "px-3 py-1 transition-colors",
         period === "ttm"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       TTM
@@ -90,7 +90,7 @@ const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
-      <p className="mb-1 font-medium text-gray-200">{`Period: ${label}`}</p>
+      <p className="mb-1 font-medium text-muted-foreground">{`Period: ${label}`}</p>
       {payload.map((pld) => (
         <p key={pld.name} style={{ color: pld.fill ?? pld.stroke }}>
           {`${pld.name}: ${formatLargeNumber(pld.value)}`}
@@ -148,7 +148,7 @@ export const CashGrowth = () => {
     <div>
       <div className="flex items-center justify-between px-4 pt-2">
         <div className="w-24" />
-        <h2 className="text-center text-xl font-semibold text-gray-200">
+        <h2 className="text-center text-xl font-semibold text-muted-foreground">
           Cash Flow
         </h2>
         <PeriodToggle period={period} onChange={setPeriod} />

--- a/src/components/features/cash_growth.tsx
+++ b/src/components/features/cash_growth.tsx
@@ -24,13 +24,13 @@ const PeriodToggle = ({
   period: Period;
   onChange: (p: Period) => void;
 }) => (
-  <div className="flex overflow-hidden rounded border border-[#424975] text-xs">
+  <div className="flex overflow-hidden rounded border border-border text-xs">
     <button
       onClick={() => onChange("quarterly")}
       className={cn(
         "px-3 py-1 transition-colors",
         period === "quarterly"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -41,7 +41,7 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "ttm"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -89,7 +89,7 @@ interface CustomTooltipProps {
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded border border-[#424975] bg-[#151624] p-3 text-sm shadow-lg">
+    <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
       <p className="mb-1 font-medium text-gray-200">{`Period: ${label}`}</p>
       {payload.map((pld) => (
         <p key={pld.name} style={{ color: pld.fill ?? pld.stroke }}>
@@ -135,7 +135,7 @@ export const CashGrowth = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center">
           <div className="mb-4 h-6 w-48 rounded bg-gray-700"></div>
           <div className="h-[400px] w-full rounded bg-gray-700"></div>

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -102,7 +102,7 @@ const RangeSelectionStats = ({
           </span>
           <span
             className={`text-sm font-bold ${
-              isPositive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"
+              isPositive ? "text-positive" : "text-negative"
             }`}
           >
             {isPositive ? "+" : ""}

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -87,7 +87,7 @@ const RangeSelectionStats = ({
 
   return (
     <div
-      className={`absolute top-2 z-50 flex items-center gap-2 rounded-lg border border-border bg-[#1a1b2e]/95 px-3 py-2 shadow-lg ${
+      className={`absolute top-2 z-50 flex items-center gap-2 rounded-lg border border-border bg-card/95 px-3 py-2 shadow-lg ${
         cursorOnRight ? "left-2" : "right-2"
       }`}
       style={{ pointerEvents: "none" }}

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -87,7 +87,7 @@ const RangeSelectionStats = ({
 
   return (
     <div
-      className={`absolute top-2 z-50 flex items-center gap-2 rounded-lg border border-[#424975] bg-[#1a1b2e]/95 px-3 py-2 shadow-lg ${
+      className={`absolute top-2 z-50 flex items-center gap-2 rounded-lg border border-border bg-[#1a1b2e]/95 px-3 py-2 shadow-lg ${
         cursorOnRight ? "left-2" : "right-2"
       }`}
       style={{ pointerEvents: "none" }}
@@ -117,7 +117,7 @@ const RangeSelectionStats = ({
             e.stopPropagation();
             onClear();
           }}
-          className="ml-1 rounded p-1 text-gray-500 hover:bg-[#424975] hover:text-white"
+          className="ml-1 rounded p-1 text-gray-500 hover:bg-secondary hover:text-white"
           title="Clear selection"
           style={{ pointerEvents: "auto" }}
         >
@@ -430,8 +430,8 @@ export function Chart() {
               }}
               className={`rounded px-3 py-1 text-sm ${
                 timeFrame === tf
-                  ? "bg-[#424975] text-white"
-                  : "bg-transparent text-gray-400 hover:bg-[#424975]/50"
+                  ? "bg-secondary text-white"
+                  : "bg-transparent text-gray-400 hover:bg-secondary/50"
               }`}
               style={{ zIndex: 100 }}
               onTouchStart={(e) => e.stopPropagation()}
@@ -457,8 +457,8 @@ export function Chart() {
               }}
               className={`rounded px-3 py-1 text-xs ${
                 indicators[key]
-                  ? "bg-[#424975] text-white"
-                  : "bg-transparent text-gray-500 hover:bg-[#424975]/50"
+                  ? "bg-secondary text-white"
+                  : "bg-transparent text-gray-500 hover:bg-secondary/50"
               }`}
               style={{ zIndex: 100 }}
               onTouchStart={(e) => e.stopPropagation()}

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -102,7 +102,7 @@ const RangeSelectionStats = ({
           </span>
           <span
             className={`text-sm font-bold ${
-              isPositive ? "text-green-400" : "text-red-400"
+              isPositive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"
             }`}
           >
             {isPositive ? "+" : ""}

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -93,11 +93,11 @@ const RangeSelectionStats = ({
       style={{ pointerEvents: "none" }}
     >
       <div className="flex flex-col">
-        <span className="text-xs text-gray-400">
+        <span className="text-xs text-muted-foreground">
           {startPoint.date} → {endPoint.date}
         </span>
         <div className="flex items-center gap-1.5">
-          <span className="text-sm font-semibold text-white">
+          <span className="text-sm font-semibold text-foreground">
             ${startPrice.toFixed(2)} → ${endPrice.toFixed(2)}
           </span>
           <span
@@ -108,7 +108,7 @@ const RangeSelectionStats = ({
             {isPositive ? "+" : ""}
             {percentChange.toFixed(2)}%
           </span>
-          <span className="text-xs text-gray-500">({days}d)</span>
+          <span className="text-xs text-muted-foreground">({days}d)</span>
         </div>
       </div>
       {!isDragging && (
@@ -117,7 +117,7 @@ const RangeSelectionStats = ({
             e.stopPropagation();
             onClear();
           }}
-          className="ml-1 rounded p-1 text-gray-500 hover:bg-secondary hover:text-white"
+          className="ml-1 rounded p-1 text-muted-foreground hover:bg-secondary hover:text-foreground"
           title="Clear selection"
           style={{ pointerEvents: "auto" }}
         >
@@ -131,8 +131,8 @@ const RangeSelectionStats = ({
 const ChartSkeleton = () => (
   <div className="flex h-full w-full items-center justify-center">
     <div className="flex flex-col items-center gap-2">
-      <LoaderCircle className="h-8 w-8 animate-spin text-gray-400" />
-      <span className="text-sm text-gray-400">Loading chart data...</span>
+      <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
+      <span className="text-sm text-muted-foreground">Loading chart data...</span>
     </div>
   </div>
 );
@@ -140,7 +140,7 @@ const ChartSkeleton = () => (
 const NoSymbolMessage = () => (
   <div className="flex h-full w-full items-center justify-center">
     <div className="flex flex-col items-center gap-2">
-      <span className="text-sm text-gray-400">
+      <span className="text-sm text-muted-foreground">
         Please select a stock to view the chart
       </span>
     </div>
@@ -157,7 +157,7 @@ const CustomTooltip = ({
   if (!active || !payload?.length) return null;
 
   return (
-    <div className="rounded-lg bg-white p-2 shadow-xs">
+    <div className="rounded-lg bg-primary p-2 shadow-xs">
       <div className="grid gap-2">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs text-cyan-700 text-muted-foreground">
@@ -430,8 +430,8 @@ export function Chart() {
               }}
               className={`rounded px-3 py-1 text-sm ${
                 timeFrame === tf
-                  ? "bg-secondary text-white"
-                  : "bg-transparent text-gray-400 hover:bg-secondary/50"
+                  ? "bg-secondary text-foreground"
+                  : "bg-transparent text-muted-foreground hover:bg-secondary/50"
               }`}
               style={{ zIndex: 100 }}
               onTouchStart={(e) => e.stopPropagation()}
@@ -457,8 +457,8 @@ export function Chart() {
               }}
               className={`rounded px-3 py-1 text-xs ${
                 indicators[key]
-                  ? "bg-secondary text-white"
-                  : "bg-transparent text-gray-500 hover:bg-secondary/50"
+                  ? "bg-secondary text-foreground"
+                  : "bg-transparent text-muted-foreground hover:bg-secondary/50"
               }`}
               style={{ zIndex: 100 }}
               onTouchStart={(e) => e.stopPropagation()}
@@ -468,7 +468,7 @@ export function Chart() {
             </button>
           ))}
         </div>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-muted-foreground">
           {isDragging ? "" : ""}
         </span>
       </div>
@@ -637,7 +637,7 @@ export function Chart() {
 
       {showRSI && (
         <div style={{ height: 90 }}>
-          <div className="px-2 pt-1 text-xs text-gray-400">RSI (14)</div>
+          <div className="px-2 pt-1 text-xs text-muted-foreground">RSI (14)</div>
           <ResponsiveContainer width="100%" height={72}>
             <ComposedChart
               data={mergedData}
@@ -677,7 +677,7 @@ export function Chart() {
 
       {showMACD && (
         <div style={{ height: 90 }}>
-          <div className="px-2 pt-1 text-xs text-gray-400">MACD (12,26,9)</div>
+          <div className="px-2 pt-1 text-xs text-muted-foreground">MACD (12,26,9)</div>
           <ResponsiveContainer width="100%" height={72}>
             <ComposedChart
               data={mergedData}

--- a/src/components/features/company-profile.tsx
+++ b/src/components/features/company-profile.tsx
@@ -61,14 +61,14 @@ export const CompanyProfile = () => {
         {rows.map(({ label, value }) =>
           value ? (
             <div key={label} className="flex items-start justify-between gap-4 text-sm">
-              <span className="shrink-0 text-gray-400">{label}</span>
+              <span className="shrink-0 text-muted-foreground">{label}</span>
               <span className="text-right font-medium text-gray-100">{value}</span>
             </div>
           ) : null,
         )}
       </div>
       {data.description && (
-        <p className="mt-4 text-sm leading-relaxed text-gray-400">{data.description}</p>
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">{data.description}</p>
       )}
     </div>
   );

--- a/src/components/features/company-profile.tsx
+++ b/src/components/features/company-profile.tsx
@@ -17,9 +17,9 @@ export const CompanyProfile = () => {
     return (
       <div className="flex animate-pulse flex-col gap-3 p-4">
         {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="h-4 rounded bg-gray-700" style={{ width: `${60 + (i % 3) * 15}%` }} />
+          <div key={i} className="h-4 rounded bg-muted" style={{ width: `${60 + (i % 3) * 15}%` }} />
         ))}
-        <div className="mt-2 h-20 rounded bg-gray-700" />
+        <div className="mt-2 h-20 rounded bg-muted" />
       </div>
     );
   }

--- a/src/components/features/company-profile.tsx
+++ b/src/components/features/company-profile.tsx
@@ -62,7 +62,7 @@ export const CompanyProfile = () => {
           value ? (
             <div key={label} className="flex items-start justify-between gap-4 text-sm">
               <span className="shrink-0 text-muted-foreground">{label}</span>
-              <span className="text-right font-medium text-gray-100">{value}</span>
+              <span className="text-right font-medium text-muted-foreground">{value}</span>
             </div>
           ) : null,
         )}

--- a/src/components/features/dividends.tsx
+++ b/src/components/features/dividends.tsx
@@ -138,8 +138,8 @@ export const Dividends = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
-          <div className="h-6 w-48 rounded bg-gray-700" />
-          <div className="h-[400px] w-full rounded bg-gray-700" />
+          <div className="h-6 w-48 rounded bg-muted" />
+          <div className="h-[400px] w-full rounded bg-muted" />
         </div>
       </div>
     );

--- a/src/components/features/dividends.tsx
+++ b/src/components/features/dividends.tsx
@@ -31,7 +31,7 @@ const PeriodToggle = ({
         "px-3 py-1 transition-colors",
         period === "quarterly"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       Quarterly
@@ -42,7 +42,7 @@ const PeriodToggle = ({
         "px-3 py-1 transition-colors",
         period === "ttm"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       TTM
@@ -94,7 +94,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
-      <p className="mb-1 font-medium text-gray-200">{formatQuarter(label ?? "")}</p>
+      <p className="mb-1 font-medium text-muted-foreground">{formatQuarter(label ?? "")}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>
           {entry.name}: ${formatLargeNumber(Math.abs(entry.value))}
@@ -149,7 +149,7 @@ export const Dividends = () => {
     <div className="w-full">
       <div className="flex items-center justify-between px-4 pt-2">
         <div className="w-24" />
-        <h2 className="text-center text-xl font-semibold text-gray-200">
+        <h2 className="text-center text-xl font-semibold text-muted-foreground">
           Dividends &amp; Return of Capital
         </h2>
         <PeriodToggle period={period} onChange={setPeriod} />

--- a/src/components/features/dividends.tsx
+++ b/src/components/features/dividends.tsx
@@ -30,8 +30,8 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "quarterly"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       Quarterly
@@ -41,8 +41,8 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "ttm"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       TTM

--- a/src/components/features/dividends.tsx
+++ b/src/components/features/dividends.tsx
@@ -24,13 +24,13 @@ const PeriodToggle = ({
   period: Period;
   onChange: (p: Period) => void;
 }) => (
-  <div className="flex overflow-hidden rounded border border-[#424975] text-xs">
+  <div className="flex overflow-hidden rounded border border-border text-xs">
     <button
       onClick={() => onChange("quarterly")}
       className={cn(
         "px-3 py-1 transition-colors",
         period === "quarterly"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -41,7 +41,7 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "ttm"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -93,7 +93,7 @@ interface TooltipProps {
 const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded border border-[#424975] bg-[#151624] p-3 text-sm shadow-lg">
+    <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
       <p className="mb-1 font-medium text-gray-200">{formatQuarter(label ?? "")}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>
@@ -136,7 +136,7 @@ export const Dividends = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
           <div className="h-6 w-48 rounded bg-gray-700" />
           <div className="h-[400px] w-full rounded bg-gray-700" />

--- a/src/components/features/earnings-calendar.tsx
+++ b/src/components/features/earnings-calendar.tsx
@@ -166,7 +166,7 @@ export function EarningsCalendar() {
               </span>
               <button
                 onClick={goToCurrentWeek}
-                className="text-xs text-primary transition-colors hover:text-primary"
+                className="text-xs text-foreground transition-colors hover:text-foreground"
               >
                 This week
               </button>
@@ -282,12 +282,12 @@ export function EarningsCalendar() {
                   >
                     <div>
                       <div
-                        className={`text-xs font-semibold uppercase tracking-wide ${today ? "text-primary" : "text-muted-foreground"}`}
+                        className={`text-xs font-semibold uppercase tracking-wide ${today ? "text-foreground" : "text-muted-foreground"}`}
                       >
                         {label.weekday}
                       </div>
                       <div
-                        className={`text-sm font-bold ${today ? "text-primary" : "text-foreground"}`}
+                        className={`text-sm font-bold ${today ? "text-foreground" : "text-foreground"}`}
                       >
                         {label.date}
                       </div>
@@ -338,7 +338,7 @@ export function EarningsCalendar() {
                                     title={company.name}
                                   >
                                     <CompanyLogo symbol={company.symbol} />
-                                    <span className="w-full truncate text-center font-mono text-[11px] font-semibold text-primary">
+                                    <span className="w-full truncate text-center font-mono text-[11px] font-semibold text-foreground">
                                       {company.symbol}
                                     </span>
                                   </div>

--- a/src/components/features/earnings-calendar.tsx
+++ b/src/components/features/earnings-calendar.tsx
@@ -61,7 +61,7 @@ function isToday(dateStr: string): boolean {
 function CompanyLogo({ symbol }: { symbol: string }) {
   const [failed, setFailed] = useState(false);
   return failed ? (
-    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-white/10 text-xs font-bold text-gray-300">
+    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-foreground/10 text-xs font-bold text-muted-foreground">
       {symbol.slice(0, 2)}
     </div>
   ) : (
@@ -146,7 +146,7 @@ export function EarningsCalendar() {
   const weekLabel = `${weekStart.toLocaleDateString("en-US", { month: "short", day: "numeric" })} – ${weekEnd.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 
   return (
-    <div className="min-h-screen bg-background pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-foreground">
       <div className="px-4 pt-4">
         {/* Controls row */}
         <div className="mb-4 flex flex-col gap-3">
@@ -156,7 +156,7 @@ export function EarningsCalendar() {
               variant="outline"
               size="sm"
               onClick={goToPrevWeek}
-              className="border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+              className="border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent"
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
@@ -166,7 +166,7 @@ export function EarningsCalendar() {
               </span>
               <button
                 onClick={goToCurrentWeek}
-                className="text-xs text-purple-400 transition-colors hover:text-purple-300"
+                className="text-xs text-primary transition-colors hover:text-primary"
               >
                 This week
               </button>
@@ -175,7 +175,7 @@ export function EarningsCalendar() {
               variant="outline"
               size="sm"
               onClick={goToNextWeek}
-              className="border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+              className="border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
@@ -184,7 +184,7 @@ export function EarningsCalendar() {
           {/* Filters row — wraps on small screens */}
           <div className="flex flex-wrap items-center justify-center gap-2">
             {/* Market cap filter */}
-            <div className="flex items-center gap-0.5 rounded-lg bg-white/5 p-1">
+            <div className="flex items-center gap-0.5 rounded-lg bg-foreground/5 p-1">
               {([0, 1e9, 10e9, 100e9] as const).map((cap) => (
                 <button
                   key={cap}
@@ -194,8 +194,8 @@ export function EarningsCalendar() {
                   }}
                   className={`rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors sm:px-3 sm:text-sm ${
                     minMarketCap === cap
-                      ? "bg-purple-600 text-white"
-                      : "text-gray-400 hover:text-white"
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground"
                   }`}
                 >
                   {cap === 0
@@ -210,7 +210,7 @@ export function EarningsCalendar() {
             </div>
 
             {/* US / Global toggle */}
-            <div className="flex items-center gap-0.5 rounded-lg bg-white/5 p-1">
+            <div className="flex items-center gap-0.5 rounded-lg bg-foreground/5 p-1">
               <button
                 onClick={() => {
                   setUsOnly(true);
@@ -218,8 +218,8 @@ export function EarningsCalendar() {
                 }}
                 className={`rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors sm:px-3 sm:text-sm ${
                   usOnly
-                    ? "bg-purple-600 text-white"
-                    : "text-gray-400 hover:text-white"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
                 }`}
               >
                 🇺🇸 US Only
@@ -231,8 +231,8 @@ export function EarningsCalendar() {
                 }}
                 className={`rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors sm:px-3 sm:text-sm ${
                   !usOnly
-                    ? "bg-purple-600 text-white"
-                    : "text-gray-400 hover:text-white"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
                 }`}
               >
                 Global
@@ -249,10 +249,10 @@ export function EarningsCalendar() {
           </div>
         ) : data && Object.keys(data).length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 py-24 text-center">
-            <p className="text-lg font-semibold text-gray-300">
+            <p className="text-lg font-semibold text-muted-foreground">
               No earnings data available
             </p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               Earnings data is typically available up to ~2 weeks ahead.
             </p>
           </div>
@@ -270,29 +270,29 @@ export function EarningsCalendar() {
                   key={dateStr}
                   className={`flex flex-col rounded-lg border ${
                     today
-                      ? "border-purple-500/60 bg-purple-900/10"
+                      ? "border-primary/60 bg-primary/10"
                       : "border-border bg-background"
                   }`}
                 >
                   {/* Day header */}
                   <div
                     className={`flex items-center justify-between rounded-t-lg px-3 py-2 ${
-                      today ? "bg-purple-500/20" : "bg-white/5"
+                      today ? "bg-primary/20" : "bg-foreground/5"
                     }`}
                   >
                     <div>
                       <div
-                        className={`text-xs font-semibold uppercase tracking-wide ${today ? "text-purple-300" : "text-gray-400"}`}
+                        className={`text-xs font-semibold uppercase tracking-wide ${today ? "text-primary" : "text-muted-foreground"}`}
                       >
                         {label.weekday}
                       </div>
                       <div
-                        className={`text-sm font-bold ${today ? "text-purple-200" : "text-white"}`}
+                        className={`text-sm font-bold ${today ? "text-primary" : "text-foreground"}`}
                       >
                         {label.date}
                       </div>
                     </div>
-                    <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs text-gray-300">
+                    <span className="rounded-full bg-foreground/10 px-2 py-0.5 text-xs text-muted-foreground">
                       {companies.length}
                     </span>
                   </div>
@@ -303,7 +303,7 @@ export function EarningsCalendar() {
                     style={{ maxHeight: "calc(100vh - 260px)" }}
                   >
                     {companies.length === 0 ? (
-                      <div className="flex h-16 items-center justify-center text-xs text-gray-500">
+                      <div className="flex h-16 items-center justify-center text-xs text-muted-foreground">
                         No earnings
                       </div>
                     ) : (
@@ -321,7 +321,7 @@ export function EarningsCalendar() {
                           if (group.length === 0) return null;
                           return (
                             <div key={groupLabel}>
-                              <div className="border-b border-white/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+                              <div className="border-b border-border px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
                                 {groupLabel}
                               </div>
                               <div
@@ -334,11 +334,11 @@ export function EarningsCalendar() {
                                 {group.map((company, idx) => (
                                   <div
                                     key={`${company.symbol}-${idx}`}
-                                    className="flex max-w-[80px] flex-col items-center gap-1 rounded-md p-1 transition-colors hover:bg-white/5"
+                                    className="flex max-w-[80px] flex-col items-center gap-1 rounded-md p-1 transition-colors hover:bg-accent"
                                     title={company.name}
                                   >
                                     <CompanyLogo symbol={company.symbol} />
-                                    <span className="w-full truncate text-center font-mono text-[11px] font-semibold text-purple-300">
+                                    <span className="w-full truncate text-center font-mono text-[11px] font-semibold text-primary">
                                       {company.symbol}
                                     </span>
                                   </div>
@@ -373,18 +373,18 @@ function DayColumnSkeleton({ dateStr }: { dateStr: string }) {
   const today = isToday(dateStr);
   return (
     <div
-      className={`rounded-lg border ${today ? "border-purple-500/60 bg-purple-900/10" : "border-border bg-background"}`}
+      className={`rounded-lg border ${today ? "border-primary/60 bg-primary/10" : "border-border bg-background"}`}
     >
       <div
-        className={`flex items-center justify-between rounded-t-lg px-3 py-2 ${today ? "bg-purple-500/20" : "bg-white/5"}`}
+        className={`flex items-center justify-between rounded-t-lg px-3 py-2 ${today ? "bg-primary/20" : "bg-foreground/5"}`}
       >
         <div>
-          <div className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {label.weekday}
           </div>
           <div className="text-sm font-bold">{label.date}</div>
         </div>
-        <div className="h-5 w-6 animate-pulse rounded-full bg-white/10" />
+        <div className="h-5 w-6 animate-pulse rounded-full bg-foreground/10" />
       </div>
       <div
         className="grid gap-0 p-2"
@@ -395,8 +395,8 @@ function DayColumnSkeleton({ dateStr }: { dateStr: string }) {
             key={i}
             className="flex max-w-[80px] flex-col items-center gap-1 p-1"
           >
-            <div className="h-10 w-10 animate-pulse rounded-md bg-white/10" />
-            <div className="h-2.5 w-8 animate-pulse rounded bg-white/10" />
+            <div className="h-10 w-10 animate-pulse rounded-md bg-foreground/10" />
+            <div className="h-2.5 w-8 animate-pulse rounded bg-foreground/10" />
           </div>
         ))}
       </div>

--- a/src/components/features/earnings-calendar.tsx
+++ b/src/components/features/earnings-calendar.tsx
@@ -60,19 +60,25 @@ function isToday(dateStr: string): boolean {
 
 function CompanyLogo({ symbol }: { symbol: string }) {
   const [failed, setFailed] = useState(false);
-  return failed ? (
-    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-foreground/10 text-xs font-bold text-muted-foreground">
-      {symbol.slice(0, 2)}
+  // Logos are transparent PNGs and some are white (built for dark backgrounds),
+  // so render every logo on a fixed dark tile that contrasts in both themes.
+  return (
+    <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-md bg-neutral-800">
+      {failed ? (
+        <span className="text-xs font-bold text-neutral-300">
+          {symbol.slice(0, 2)}
+        </span>
+      ) : (
+        <Image
+          src={`https://financialmodelingprep.com/image-stock/${symbol}.png`}
+          alt={symbol}
+          width={40}
+          height={40}
+          className="h-full w-full object-contain p-1"
+          onError={() => setFailed(true)}
+        />
+      )}
     </div>
-  ) : (
-    <Image
-      src={`https://financialmodelingprep.com/image-stock/${symbol}.png`}
-      alt={symbol}
-      width={40}
-      height={40}
-      className="rounded-md object-contain"
-      onError={() => setFailed(true)}
-    />
   );
 }
 

--- a/src/components/features/earnings-calendar.tsx
+++ b/src/components/features/earnings-calendar.tsx
@@ -146,7 +146,7 @@ export function EarningsCalendar() {
   const weekLabel = `${weekStart.toLocaleDateString("en-US", { month: "short", day: "numeric" })} – ${weekEnd.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 
   return (
-    <div className="min-h-screen bg-[#15162c] pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-white">
       <div className="px-4 pt-4">
         {/* Controls row */}
         <div className="mb-4 flex flex-col gap-3">
@@ -271,7 +271,7 @@ export function EarningsCalendar() {
                   className={`flex flex-col rounded-lg border ${
                     today
                       ? "border-purple-500/60 bg-purple-900/10"
-                      : "border-[#424975] bg-[#151624]"
+                      : "border-border bg-background"
                   }`}
                 >
                   {/* Day header */}
@@ -373,7 +373,7 @@ function DayColumnSkeleton({ dateStr }: { dateStr: string }) {
   const today = isToday(dateStr);
   return (
     <div
-      className={`rounded-lg border ${today ? "border-purple-500/60 bg-purple-900/10" : "border-[#424975] bg-[#151624]"}`}
+      className={`rounded-lg border ${today ? "border-purple-500/60 bg-purple-900/10" : "border-border bg-background"}`}
     >
       <div
         className={`flex items-center justify-between rounded-t-lg px-3 py-2 ${today ? "bg-purple-500/20" : "bg-white/5"}`}

--- a/src/components/features/eps.tsx
+++ b/src/components/features/eps.tsx
@@ -69,7 +69,7 @@ export const HistoricalEPS = () => {
 
   return (
     <div className="w-full">
-      <h2 className="mt-2 text-center text-xl font-semibold text-gray-200">
+      <h2 className="mt-2 text-center text-xl font-semibold text-muted-foreground">
         Earnings Per Share
       </h2>
       <ResponsiveContainer width="100%" height={500}>

--- a/src/components/features/eps.tsx
+++ b/src/components/features/eps.tsx
@@ -33,7 +33,7 @@ interface CustomTooltipProps {
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (active && payload?.length) {
     return (
-      <div className="rounded-lg border bg-white p-4 shadow-xs">
+      <div className="rounded-lg border bg-primary p-4 shadow-xs">
         <p className="mb-2 font-medium">{formatQuarter(label)}</p>
         {payload.map((entry) => (
           <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>

--- a/src/components/features/fundamentals.tsx
+++ b/src/components/features/fundamentals.tsx
@@ -32,7 +32,7 @@ const Row = ({
   <div className="flex items-baseline justify-between gap-1">
     <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
     <div className="text-right">
-      <span className={`font-mono text-sm font-medium ${color ?? "text-gray-200"}`}>
+      <span className={`font-mono text-sm font-medium ${color ?? "text-muted-foreground"}`}>
         {value}
       </span>
       {sub && <div className="text-[10px] text-muted-foreground">{sub}</div>}

--- a/src/components/features/fundamentals.tsx
+++ b/src/components/features/fundamentals.tsx
@@ -157,7 +157,7 @@ export const Fundamentals = () => {
           <Row
             label="SBC Impact"
             value={`-${fmtPct(Math.abs(sbcImpact))}`}
-            color="text-red-700 dark:text-red-400"
+            color="text-negative"
           />
         </Section>
 
@@ -169,14 +169,14 @@ export const Fundamentals = () => {
             <Row
               label="Revenue (YoY)"
               value={yoy(revenueYoY)}
-              color={revenueYoY >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
+              color={revenueYoY >= 0 ? "text-positive" : "text-negative"}
             />
           )}
           {epsYoY !== null && (
             <Row
               label="Earnings (YoY)"
               value={yoy(epsYoY)}
-              color={epsYoY >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
+              color={epsYoY >= 0 ? "text-positive" : "text-negative"}
             />
           )}
         </Section>
@@ -188,7 +188,7 @@ export const Fundamentals = () => {
           <Row
             label="Net Cash"
             value={`${netCash >= 0 ? "" : "-"}$${formatLargeNumber(Math.abs(netCash))}`}
-            color={netCash >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
+            color={netCash >= 0 ? "text-positive" : "text-negative"}
           />
         </Section>
 

--- a/src/components/features/fundamentals.tsx
+++ b/src/components/features/fundamentals.tsx
@@ -30,12 +30,12 @@ const Row = ({
   color?: string;
 }) => (
   <div className="flex items-baseline justify-between gap-1">
-    <span className="shrink-0 text-xs text-gray-400">{label}</span>
+    <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
     <div className="text-right">
       <span className={`font-mono text-sm font-medium ${color ?? "text-gray-200"}`}>
         {value}
       </span>
-      {sub && <div className="text-[10px] text-gray-500">{sub}</div>}
+      {sub && <div className="text-[10px] text-muted-foreground">{sub}</div>}
     </div>
   </div>
 );

--- a/src/components/features/fundamentals.tsx
+++ b/src/components/features/fundamentals.tsx
@@ -70,7 +70,7 @@ export const Fundamentals = () => {
       <div className="h-full w-full animate-pulse p-3">
         <div className="flex flex-wrap gap-6">
           {Array.from({ length: 10 }).map((_, i) => (
-            <div key={i} className="h-3 w-36 rounded bg-gray-700" />
+            <div key={i} className="h-3 w-36 rounded bg-muted" />
           ))}
         </div>
       </div>

--- a/src/components/features/fundamentals.tsx
+++ b/src/components/features/fundamentals.tsx
@@ -157,7 +157,7 @@ export const Fundamentals = () => {
           <Row
             label="SBC Impact"
             value={`-${fmtPct(Math.abs(sbcImpact))}`}
-            color="text-red-400"
+            color="text-red-700 dark:text-red-400"
           />
         </Section>
 
@@ -169,14 +169,14 @@ export const Fundamentals = () => {
             <Row
               label="Revenue (YoY)"
               value={yoy(revenueYoY)}
-              color={revenueYoY >= 0 ? "text-green-400" : "text-red-400"}
+              color={revenueYoY >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
             />
           )}
           {epsYoY !== null && (
             <Row
               label="Earnings (YoY)"
               value={yoy(epsYoY)}
-              color={epsYoY >= 0 ? "text-green-400" : "text-red-400"}
+              color={epsYoY >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
             />
           )}
         </Section>
@@ -188,7 +188,7 @@ export const Fundamentals = () => {
           <Row
             label="Net Cash"
             value={`${netCash >= 0 ? "" : "-"}$${formatLargeNumber(Math.abs(netCash))}`}
-            color={netCash >= 0 ? "text-green-400" : "text-red-400"}
+            color={netCash >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
           />
         </Section>
 

--- a/src/components/features/gpt.tsx
+++ b/src/components/features/gpt.tsx
@@ -112,7 +112,7 @@ export const GPT = () => {
             <p>Input data: live quote, fundamental metrics, news summary</p>
           </div>
           <Button
-            className="self-end border border-border bg-slate-900 text-foreground hover:bg-slate-600"
+            className="self-end border border-border bg-primary text-primary-foreground hover:bg-primary/90"
             variant="secondary"
             disabled={isPending}
           >
@@ -122,7 +122,7 @@ export const GPT = () => {
               width={20}
               height={20}
               alt="gpt"
-              color="white"
+              className="brightness-0"
               style={{
                 animation: isPending ? "spin 1s linear infinite" : undefined,
               }}
@@ -139,15 +139,15 @@ export const GPT = () => {
       {data && data.supabaseId === symbol ? (
         <div className="mt-4">
           <div className="relative mt-2">
-            <div className="scrollbar-thin scrollbar-track-gray-800 scrollbar-thumb-gray-600 max-h-[500px] overflow-y-auto rounded-lg border border-gray-700 bg-gray-800/50 p-4 py-8">
+            <div className="scrollbar-thin scrollbar-track-secondary scrollbar-thumb-border max-h-[500px] overflow-y-auto rounded-lg border border-border bg-card p-4 py-8">
               {data.response ? (
                 <MarkdownWithColor content={data.response} />
               ) : null}
             </div>
-            <div className="pointer-events-none absolute bottom-0 h-8 w-full bg-linear-to-t from-gray-900 to-transparent" />
+            <div className="pointer-events-none absolute bottom-0 h-8 w-full bg-linear-to-t from-card to-transparent" />
             {data.response ? (
               <Button
-                className="absolute right-2 top-2 h-8 w-8 border border-border bg-gray-800/80 text-muted-foreground hover:bg-accent hover:text-foreground"
+                className="absolute right-2 top-2 h-8 w-8 border border-border bg-card/80 text-muted-foreground hover:bg-accent hover:text-foreground"
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsModalOpen(true)}
@@ -169,12 +169,12 @@ export const GPT = () => {
 
       {isPending ? (
         <div className="mt-4 space-y-4">
-          <div className="h-4 w-48 animate-pulse rounded-md bg-gray-700" />
+          <div className="h-4 w-48 animate-pulse rounded-md bg-muted" />
           <div className="space-y-3">
-            <div className="h-4 w-full animate-pulse rounded-md bg-gray-700" />
-            <div className="h-4 w-3/4 animate-pulse rounded-md bg-gray-700" />
-            <div className="h-4 w-5/6 animate-pulse rounded-md bg-gray-700" />
-            <div className="h-4 w-2/3 animate-pulse rounded-md bg-gray-700" />
+            <div className="h-4 w-full animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-5/6 animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-2/3 animate-pulse rounded-md bg-muted" />
           </div>
         </div>
       ) : null}

--- a/src/components/features/gpt.tsx
+++ b/src/components/features/gpt.tsx
@@ -13,7 +13,7 @@ import "~/styles/markdown.css";
 
 const MarkdownWithColor = ({ content }: { content: string }) => {
   return (
-    <div className="prose prose-invert max-w-none text-sm">
+    <div className="prose dark:prose-invert max-w-none text-sm">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -64,7 +64,7 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
             }
             if (className) {
               return (
-                <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-gray-200">
+                <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-muted-foreground">
                   <code>{children}</code>
                 </pre>
               );

--- a/src/components/features/gpt.tsx
+++ b/src/components/features/gpt.tsx
@@ -18,7 +18,7 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
         remarkPlugins={[remarkGfm]}
         components={{
           p: ({ children }) => {
-            return <p className="mt-2 text-white">{children}</p>;
+            return <p className="mt-2 text-foreground">{children}</p>;
           },
           strong: ({ children }) => {
             const text = typeof children === "string" ? children : null;
@@ -51,7 +51,7 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
           },
           h1: ({ children }) => {
             return (
-              <h1 className="text-2xl font-bold text-white">{children}</h1>
+              <h1 className="text-2xl font-bold text-foreground">{children}</h1>
             );
           },
           pre: ({ children }) => {
@@ -64,7 +64,7 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
             }
             if (className) {
               return (
-                <pre className="overflow-x-auto rounded-md bg-white/10 p-3 text-sm text-gray-200">
+                <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-gray-200">
                   <code>{children}</code>
                 </pre>
               );
@@ -112,7 +112,7 @@ export const GPT = () => {
             <p>Input data: live quote, fundamental metrics, news summary</p>
           </div>
           <Button
-            className="self-end border border-white bg-slate-900 text-white hover:bg-slate-600"
+            className="self-end border border-border bg-slate-900 text-foreground hover:bg-slate-600"
             variant="secondary"
             disabled={isPending}
           >
@@ -130,7 +130,7 @@ export const GPT = () => {
           </Button>
         </div>
         {data && data.supabaseId === symbol ? (
-          <p className="self-end text-xs text-gray-400">
+          <p className="self-end text-xs text-muted-foreground">
             {`Updated at: ${Intl.DateTimeFormat().format(new Date(data.updatedAt ?? data.createdAt))}`}
           </p>
         ) : null}
@@ -147,7 +147,7 @@ export const GPT = () => {
             <div className="pointer-events-none absolute bottom-0 h-8 w-full bg-linear-to-t from-gray-900 to-transparent" />
             {data.response ? (
               <Button
-                className="absolute right-2 top-2 h-8 w-8 border border-white/20 bg-gray-800/80 text-gray-300 hover:bg-white/20 hover:text-white"
+                className="absolute right-2 top-2 h-8 w-8 border border-border bg-gray-800/80 text-muted-foreground hover:bg-accent hover:text-foreground"
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsModalOpen(true)}
@@ -161,7 +161,7 @@ export const GPT = () => {
       ) : null}
 
       {isSuccess && !data?.recommendation && !isPending && !error ? (
-        <div className="mt-4 text-sm text-gray-400">
+        <div className="mt-4 text-sm text-muted-foreground">
           Empty report for this stock 😔. Try again later! Or email me to run it
           manually. 🚀
         </div>

--- a/src/components/features/grid.tsx
+++ b/src/components/features/grid.tsx
@@ -37,7 +37,7 @@ const Grid = () => {
 
   if (!width || !height) return null;
 
-  const clx = "border border-sm border-[#424975] bg-[#151624]";
+  const clx = "border border-sm border-border bg-background";
 
   return (
     <>

--- a/src/components/features/income-statement-charts.tsx
+++ b/src/components/features/income-statement-charts.tsx
@@ -34,7 +34,7 @@ const PeriodToggle = ({
         "px-3 py-1 transition-colors",
         period === "quarterly"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       Quarterly
@@ -45,7 +45,7 @@ const PeriodToggle = ({
         "px-3 py-1 transition-colors",
         period === "ttm"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       TTM
@@ -106,7 +106,7 @@ const ChartTooltip = ({ active, payload, label, format }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
-      <p className="mb-1 font-medium text-gray-200">{formatQuarter(label)}</p>
+      <p className="mb-1 font-medium text-muted-foreground">{formatQuarter(label)}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>
           {entry.name}: {format(entry.value)}
@@ -152,7 +152,7 @@ const IncomeChart = ({
     <div className="w-full">
       <div className="flex items-center justify-between px-4 pt-2">
         <div className="w-24" />
-        <h2 className="text-center text-xl font-semibold text-gray-200">
+        <h2 className="text-center text-xl font-semibold text-muted-foreground">
           {config.title}
         </h2>
         <PeriodToggle period={period} onChange={onPeriodChange} />
@@ -371,7 +371,7 @@ export const MarginTrends = () => {
     <div className="w-full">
       <div className="flex items-center justify-between px-4 pt-2">
         <div className="w-24" />
-        <h2 className="text-center text-xl font-semibold text-gray-200">Margin Trends</h2>
+        <h2 className="text-center text-xl font-semibold text-muted-foreground">Margin Trends</h2>
         <PeriodToggle period={period} onChange={setPeriod} />
       </div>
       <ResponsiveContainer width="100%" height={480}>
@@ -431,7 +431,7 @@ export const SharesOutstanding = () => {
 
   return (
     <div className="w-full">
-      <h2 className="mt-2 text-center text-xl font-semibold text-gray-200">
+      <h2 className="mt-2 text-center text-xl font-semibold text-muted-foreground">
         Shares Outstanding
       </h2>
       <ResponsiveContainer width="100%" height={480}>

--- a/src/components/features/income-statement-charts.tsx
+++ b/src/components/features/income-statement-charts.tsx
@@ -141,8 +141,8 @@ const IncomeChart = ({
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
-          <div className="h-6 w-48 rounded bg-gray-700" />
-          <div className="h-[400px] w-full rounded bg-gray-700" />
+          <div className="h-6 w-48 rounded bg-muted" />
+          <div className="h-[400px] w-full rounded bg-muted" />
         </div>
       </div>
     );
@@ -360,8 +360,8 @@ export const MarginTrends = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
-          <div className="h-6 w-48 rounded bg-gray-700" />
-          <div className="h-[400px] w-full rounded bg-gray-700" />
+          <div className="h-6 w-48 rounded bg-muted" />
+          <div className="h-[400px] w-full rounded bg-muted" />
         </div>
       </div>
     );
@@ -422,8 +422,8 @@ export const SharesOutstanding = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
-          <div className="h-6 w-48 rounded bg-gray-700" />
-          <div className="h-[400px] w-full rounded bg-gray-700" />
+          <div className="h-6 w-48 rounded bg-muted" />
+          <div className="h-[400px] w-full rounded bg-muted" />
         </div>
       </div>
     );

--- a/src/components/features/income-statement-charts.tsx
+++ b/src/components/features/income-statement-charts.tsx
@@ -27,13 +27,13 @@ const PeriodToggle = ({
   period: Period;
   onChange: (p: Period) => void;
 }) => (
-  <div className="flex overflow-hidden rounded border border-[#424975] text-xs">
+  <div className="flex overflow-hidden rounded border border-border text-xs">
     <button
       onClick={() => onChange("quarterly")}
       className={cn(
         "px-3 py-1 transition-colors",
         period === "quarterly"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -44,7 +44,7 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "ttm"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -105,7 +105,7 @@ interface TooltipProps {
 const ChartTooltip = ({ active, payload, label, format }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded border border-[#424975] bg-[#151624] p-3 text-sm shadow-lg">
+    <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
       <p className="mb-1 font-medium text-gray-200">{formatQuarter(label)}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>
@@ -139,7 +139,7 @@ const IncomeChart = ({
 }) => {
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
           <div className="h-6 w-48 rounded bg-gray-700" />
           <div className="h-[400px] w-full rounded bg-gray-700" />
@@ -358,7 +358,7 @@ export const MarginTrends = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
           <div className="h-6 w-48 rounded bg-gray-700" />
           <div className="h-[400px] w-full rounded bg-gray-700" />
@@ -420,7 +420,7 @@ export const SharesOutstanding = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
           <div className="h-6 w-48 rounded bg-gray-700" />
           <div className="h-[400px] w-full rounded bg-gray-700" />

--- a/src/components/features/income-statement-charts.tsx
+++ b/src/components/features/income-statement-charts.tsx
@@ -33,8 +33,8 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "quarterly"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       Quarterly
@@ -44,8 +44,8 @@ const PeriodToggle = ({
       className={cn(
         "px-3 py-1 transition-colors",
         period === "ttm"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       TTM

--- a/src/components/features/influencer-digest.tsx
+++ b/src/components/features/influencer-digest.tsx
@@ -65,7 +65,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
       </CardHeader>
 
       <CardContent className="space-y-5">
-        <p className="text-sm leading-relaxed text-gray-200">
+        <p className="text-sm leading-relaxed text-muted-foreground">
           {digest.marketSentiment}
         </p>
 
@@ -74,7 +74,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
             {digest.keyThemes.map((theme, i) => (
               <Pill
                 key={i}
-                className="bg-primary/15 text-primary ring-primary/30"
+                className="bg-primary/15 text-foreground ring-primary/30"
               >
                 {theme}
               </Pill>
@@ -113,7 +113,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
                 className="flex items-start gap-2 rounded-md bg-black/20 px-3 py-2 text-sm"
               >
                 {a.action && (
-                  <Pill className="mt-0.5 shrink-0 bg-primary/15 text-primary ring-primary/30">
+                  <Pill className="mt-0.5 shrink-0 bg-primary/15 text-foreground ring-primary/30">
                     {a.action}
                   </Pill>
                 )}

--- a/src/components/features/influencer-digest.tsx
+++ b/src/components/features/influencer-digest.tsx
@@ -53,11 +53,11 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
   ].filter(Boolean);
 
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
         <div>
           <h2 className="text-lg font-semibold">Daily Market Digest</h2>
-          <p className="text-xs text-gray-400">{meta.join(" · ")}</p>
+          <p className="text-xs text-muted-foreground">{meta.join(" · ")}</p>
         </div>
         {digest.sentimentLabel && (
           <SentimentBadge label={digest.sentimentLabel} />
@@ -74,7 +74,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
             {digest.keyThemes.map((theme, i) => (
               <Pill
                 key={i}
-                className="bg-purple-500/15 text-purple-200 ring-purple-500/30"
+                className="bg-primary/15 text-primary ring-primary/30"
               >
                 {theme}
               </Pill>
@@ -84,19 +84,19 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
 
         {rotations.length > 0 && (
           <div className="space-y-2">
-            <div className="flex items-center gap-1.5 text-xs font-medium text-gray-300">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
               <Repeat className="h-3.5 w-3.5" /> Sector rotation
             </div>
             {rotations.map((r, i) => (
               <div key={i} className="rounded-md bg-black/20 px-3 py-2 text-sm">
                 {(r.from ?? r.to) && (
-                  <div className="mb-0.5 flex items-center gap-1.5 text-xs font-medium text-white">
+                  <div className="mb-0.5 flex items-center gap-1.5 text-xs font-medium text-foreground">
                     {r.from && <span>{r.from}</span>}
-                    <ArrowRight className="h-3 w-3 text-gray-500" />
+                    <ArrowRight className="h-3 w-3 text-muted-foreground" />
                     {r.to && <span>{r.to}</span>}
                   </div>
                 )}
-                <p className="text-gray-300">{r.rationale}</p>
+                <p className="text-muted-foreground">{r.rationale}</p>
               </div>
             ))}
           </div>
@@ -104,7 +104,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
 
         {actions.length > 0 && (
           <div className="space-y-2">
-            <div className="flex items-center gap-1.5 text-xs font-medium text-gray-300">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
               <Lightbulb className="h-3.5 w-3.5" /> Recommended actions
             </div>
             {actions.map((a, i) => (
@@ -113,13 +113,13 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
                 className="flex items-start gap-2 rounded-md bg-black/20 px-3 py-2 text-sm"
               >
                 {a.action && (
-                  <Pill className="mt-0.5 shrink-0 bg-purple-500/15 text-purple-200 ring-purple-500/30">
+                  <Pill className="mt-0.5 shrink-0 bg-primary/15 text-primary ring-primary/30">
                     {a.action}
                   </Pill>
                 )}
-                <p className="text-gray-300">
+                <p className="text-muted-foreground">
                   {a.symbol && (
-                    <span className="font-semibold text-white">{a.symbol}: </span>
+                    <span className="font-semibold text-foreground">{a.symbol}: </span>
                   )}
                   {a.rationale}
                 </p>

--- a/src/components/features/influencer-digest.tsx
+++ b/src/components/features/influencer-digest.tsx
@@ -88,7 +88,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
               <Repeat className="h-3.5 w-3.5" /> Sector rotation
             </div>
             {rotations.map((r, i) => (
-              <div key={i} className="rounded-md bg-black/20 px-3 py-2 text-sm">
+              <div key={i} className="rounded-md bg-muted px-3 py-2 text-sm">
                 {(r.from ?? r.to) && (
                   <div className="mb-0.5 flex items-center gap-1.5 text-xs font-medium text-foreground">
                     {r.from && <span>{r.from}</span>}
@@ -110,7 +110,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
             {actions.map((a, i) => (
               <div
                 key={i}
-                className="flex items-start gap-2 rounded-md bg-black/20 px-3 py-2 text-sm"
+                className="flex items-start gap-2 rounded-md bg-muted px-3 py-2 text-sm"
               >
                 {a.action && (
                   <Pill className="mt-0.5 shrink-0 bg-primary/15 text-foreground ring-primary/30">

--- a/src/components/features/influencer-roster.tsx
+++ b/src/components/features/influencer-roster.tsx
@@ -34,7 +34,7 @@ function Row({ inf }: { inf: Influencer }) {
     >
       <Avatar className="h-9 w-9 shrink-0">
         {inf.avatar && <AvatarImage src={inf.avatar} alt={inf.name} />}
-        <AvatarFallback className="bg-primary/20 text-xs text-primary">
+        <AvatarFallback className="bg-primary/20 text-xs text-foreground">
           {initials(inf.name)}
         </AvatarFallback>
       </Avatar>

--- a/src/components/features/influencer-roster.tsx
+++ b/src/components/features/influencer-roster.tsx
@@ -30,24 +30,24 @@ function Row({ inf }: { inf: Influencer }) {
       href={channelUrl(inf)}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex items-center gap-3 rounded-md px-2 py-2 transition-colors hover:bg-white/5"
+      className="group flex items-center gap-3 rounded-md px-2 py-2 transition-colors hover:bg-accent"
     >
       <Avatar className="h-9 w-9 shrink-0">
         {inf.avatar && <AvatarImage src={inf.avatar} alt={inf.name} />}
-        <AvatarFallback className="bg-purple-500/20 text-xs text-purple-200">
+        <AvatarFallback className="bg-primary/20 text-xs text-primary">
           {initials(inf.name)}
         </AvatarFallback>
       </Avatar>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <span className="truncate font-medium text-white group-hover:underline">
+          <span className="truncate font-medium text-foreground group-hover:underline">
             {inf.name}
           </span>
           <Youtube className="h-3.5 w-3.5 shrink-0 text-rose-400" />
         </div>
-        {inf.handle && <p className="truncate text-xs text-gray-500">{inf.handle}</p>}
+        {inf.handle && <p className="truncate text-xs text-muted-foreground">{inf.handle}</p>}
       </div>
-      <div className="shrink-0 text-right text-xs text-gray-400">
+      <div className="shrink-0 text-right text-xs text-muted-foreground">
         <div>{inf.videoCount} videos</div>
         <div className="text-gray-600">{formatRelative(inf.lastPublishedAt)}</div>
       </div>
@@ -61,13 +61,13 @@ export function InfluencerRoster({
   influencers: Influencer[];
 }) {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="pb-3">
         <h2 className="text-sm font-semibold">Tracked creators ({(influencers?.length ?? 0)})</h2>
       </CardHeader>
       <CardContent className="space-y-0.5">
         {(influencers?.length ?? 0) === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-500">
+          <p className="py-6 text-center text-sm text-muted-foreground">
             No creators yet.
           </p>
         ) : (

--- a/src/components/features/influencer-roster.tsx
+++ b/src/components/features/influencer-roster.tsx
@@ -43,7 +43,7 @@ function Row({ inf }: { inf: Influencer }) {
           <span className="truncate font-medium text-foreground group-hover:underline">
             {inf.name}
           </span>
-          <Youtube className="h-3.5 w-3.5 shrink-0 text-rose-700 dark:text-rose-400" />
+          <Youtube className="h-3.5 w-3.5 shrink-0 text-negative" />
         </div>
         {inf.handle && <p className="truncate text-xs text-muted-foreground">{inf.handle}</p>}
       </div>

--- a/src/components/features/influencer-roster.tsx
+++ b/src/components/features/influencer-roster.tsx
@@ -43,7 +43,7 @@ function Row({ inf }: { inf: Influencer }) {
           <span className="truncate font-medium text-foreground group-hover:underline">
             {inf.name}
           </span>
-          <Youtube className="h-3.5 w-3.5 shrink-0 text-rose-400" />
+          <Youtube className="h-3.5 w-3.5 shrink-0 text-rose-700 dark:text-rose-400" />
         </div>
         {inf.handle && <p className="truncate text-xs text-muted-foreground">{inf.handle}</p>}
       </div>

--- a/src/components/features/influencer-sentiment.tsx
+++ b/src/components/features/influencer-sentiment.tsx
@@ -56,7 +56,7 @@ function CreatorCount({
 
 function SymbolRow({ row, rank }: { row: Row; rank: number }) {
   return (
-    <div className="flex items-center gap-3 rounded-md bg-black/20 px-3 py-2">
+    <div className="flex items-center gap-3 rounded-md bg-muted px-3 py-2">
       <span className="w-4 shrink-0 text-right text-xs text-muted-foreground">{rank}</span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -71,13 +71,13 @@ function SymbolRow({ row, rank }: { row: Row; rank: number }) {
         <CreatorCount
           count={row.bullishCount}
           arrow="↑"
-          color="text-emerald-400"
+          color="text-emerald-700 dark:text-emerald-400"
           names={row.bullishCreators ?? []}
         />{" "}
         <CreatorCount
           count={row.bearishCount}
           arrow="↓"
-          color="text-rose-400"
+          color="text-rose-700 dark:text-rose-400"
           names={row.bearishCreators ?? []}
         />
         {row.neutralCount > 0 && (
@@ -134,14 +134,14 @@ export function SentimentLeaderboard({ sentiment }: { sentiment: Sentiment }) {
         <LeaderCard
           title="Most bullish"
           icon={<Flame className="h-4 w-4" />}
-          accent="text-emerald-400"
+          accent="text-emerald-700 dark:text-emerald-400"
           rows={sentiment.bullish}
           empty="No bullish consensus yet."
         />
         <LeaderCard
           title="Most bearish"
           icon={<Snowflake className="h-4 w-4" />}
-          accent="text-rose-400"
+          accent="text-rose-700 dark:text-rose-400"
           rows={sentiment.bearish}
           empty="No bearish consensus yet."
         />

--- a/src/components/features/influencer-sentiment.tsx
+++ b/src/components/features/influencer-sentiment.tsx
@@ -57,14 +57,14 @@ function CreatorCount({
 function SymbolRow({ row, rank }: { row: Row; rank: number }) {
   return (
     <div className="flex items-center gap-3 rounded-md bg-black/20 px-3 py-2">
-      <span className="w-4 shrink-0 text-right text-xs text-gray-500">{rank}</span>
+      <span className="w-4 shrink-0 text-right text-xs text-muted-foreground">{rank}</span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="font-semibold text-white">{row.symbol}</span>
+          <span className="font-semibold text-foreground">{row.symbol}</span>
           <ConsensusBadge consensus={row.consensus} />
         </div>
         {row.companyName && (
-          <p className="truncate text-xs text-gray-500">{row.companyName}</p>
+          <p className="truncate text-xs text-muted-foreground">{row.companyName}</p>
         )}
       </div>
       <div className="shrink-0 text-right text-sm">
@@ -110,7 +110,7 @@ function LeaderCard({
   empty: string;
 }) {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="space-y-0 pb-3">
         <div className={`flex items-center gap-2 text-sm font-semibold ${accent}`}>
           {icon} {title}
@@ -118,7 +118,7 @@ function LeaderCard({
       </CardHeader>
       <CardContent className="space-y-1.5">
         {rows.length === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-500">{empty}</p>
+          <p className="py-6 text-center text-sm text-muted-foreground">{empty}</p>
         ) : (
           rows.map((row, i) => <SymbolRow key={row.symbol} row={row} rank={i + 1} />)
         )}

--- a/src/components/features/influencer-sentiment.tsx
+++ b/src/components/features/influencer-sentiment.tsx
@@ -71,13 +71,13 @@ function SymbolRow({ row, rank }: { row: Row; rank: number }) {
         <CreatorCount
           count={row.bullishCount}
           arrow="↑"
-          color="text-emerald-700 dark:text-emerald-400"
+          color="text-positive"
           names={row.bullishCreators ?? []}
         />{" "}
         <CreatorCount
           count={row.bearishCount}
           arrow="↓"
-          color="text-rose-700 dark:text-rose-400"
+          color="text-negative"
           names={row.bearishCreators ?? []}
         />
         {row.neutralCount > 0 && (
@@ -134,14 +134,14 @@ export function SentimentLeaderboard({ sentiment }: { sentiment: Sentiment }) {
         <LeaderCard
           title="Most bullish"
           icon={<Flame className="h-4 w-4" />}
-          accent="text-emerald-700 dark:text-emerald-400"
+          accent="text-positive"
           rows={sentiment.bullish}
           empty="No bullish consensus yet."
         />
         <LeaderCard
           title="Most bearish"
           icon={<Snowflake className="h-4 w-4" />}
-          accent="text-rose-700 dark:text-rose-400"
+          accent="text-negative"
           rows={sentiment.bearish}
           empty="No bearish consensus yet."
         />

--- a/src/components/features/influencer-shared.tsx
+++ b/src/components/features/influencer-shared.tsx
@@ -3,25 +3,25 @@ import { cn } from "~/lib/utils";
 
 const STANCE_NEUTRAL = "bg-slate-500/15 text-muted-foreground ring-slate-500/30";
 const STANCE_STYLES: Record<string, string> = {
-  bullish: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
-  bearish: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
+  bullish: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
+  bearish: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
   neutral: STANCE_NEUTRAL,
 };
 
-const CONSENSUS_MIXED = "bg-amber-500/15 text-amber-300 ring-amber-500/30";
+const CONSENSUS_MIXED = "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30";
 const CONSENSUS_STYLES: Record<string, string> = {
   strong_bullish: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
-  bullish: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/25",
+  bullish: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
   mixed: CONSENSUS_MIXED,
-  bearish: "bg-rose-500/10 text-rose-300 ring-rose-500/25",
+  bearish: "bg-rose-500/10 text-rose-700 dark:text-rose-400 ring-rose-500/25",
   strong_bearish: "bg-rose-500/20 text-rose-200 ring-rose-500/40",
 };
 
-const SENTIMENT_NEUTRAL = "bg-amber-500/15 text-amber-300 ring-amber-500/30";
+const SENTIMENT_NEUTRAL = "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30";
 const SENTIMENT_STYLES: Record<string, string> = {
-  risk_on: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
+  risk_on: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
   neutral: SENTIMENT_NEUTRAL,
-  risk_off: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
+  risk_off: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
 };
 
 export function Pill({
@@ -64,8 +64,8 @@ export function SentimentBadge({ label }: { label: string }) {
 }
 
 export function netColor(net: number): string {
-  if (net > 0) return "text-emerald-400";
-  if (net < 0) return "text-rose-400";
+  if (net > 0) return "text-emerald-700 dark:text-emerald-400";
+  if (net < 0) return "text-rose-700 dark:text-rose-400";
   return "text-slate-400";
 }
 

--- a/src/components/features/influencer-shared.tsx
+++ b/src/components/features/influencer-shared.tsx
@@ -3,25 +3,25 @@ import { cn } from "~/lib/utils";
 
 const STANCE_NEUTRAL = "bg-slate-500/15 text-muted-foreground ring-slate-500/30";
 const STANCE_STYLES: Record<string, string> = {
-  bullish: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
-  bearish: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
+  bullish: "bg-positive-surface text-positive ring-positive/30",
+  bearish: "bg-negative-surface text-negative ring-negative/30",
   neutral: STANCE_NEUTRAL,
 };
 
-const CONSENSUS_MIXED = "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30";
+const CONSENSUS_MIXED = "bg-warning-surface text-warning ring-warning/30";
 const CONSENSUS_STYLES: Record<string, string> = {
-  strong_bullish: "bg-emerald-500/20 text-emerald-800 dark:text-emerald-200 ring-emerald-500/40",
-  bullish: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
+  strong_bullish: "bg-positive-surface text-positive ring-positive/30",
+  bullish: "bg-positive-surface text-positive ring-positive/30",
   mixed: CONSENSUS_MIXED,
-  bearish: "bg-rose-500/10 text-rose-700 dark:text-rose-400 ring-rose-500/25",
-  strong_bearish: "bg-rose-500/20 text-rose-800 dark:text-rose-200 ring-rose-500/40",
+  bearish: "bg-negative-surface text-negative ring-negative/30",
+  strong_bearish: "bg-negative-surface text-negative ring-negative/30",
 };
 
-const SENTIMENT_NEUTRAL = "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30";
+const SENTIMENT_NEUTRAL = "bg-warning-surface text-warning ring-warning/30";
 const SENTIMENT_STYLES: Record<string, string> = {
-  risk_on: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
+  risk_on: "bg-positive-surface text-positive ring-positive/30",
   neutral: SENTIMENT_NEUTRAL,
-  risk_off: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
+  risk_off: "bg-negative-surface text-negative ring-negative/30",
 };
 
 export function Pill({
@@ -64,8 +64,8 @@ export function SentimentBadge({ label }: { label: string }) {
 }
 
 export function netColor(net: number): string {
-  if (net > 0) return "text-emerald-700 dark:text-emerald-400";
-  if (net < 0) return "text-rose-700 dark:text-rose-400";
+  if (net > 0) return "text-positive";
+  if (net < 0) return "text-negative";
   return "text-slate-400";
 }
 

--- a/src/components/features/influencer-shared.tsx
+++ b/src/components/features/influencer-shared.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import { cn } from "~/lib/utils";
 
-const STANCE_NEUTRAL = "bg-slate-500/15 text-slate-300 ring-slate-500/30";
+const STANCE_NEUTRAL = "bg-slate-500/15 text-muted-foreground ring-slate-500/30";
 const STANCE_STYLES: Record<string, string> = {
   bullish: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
   bearish: "bg-rose-500/15 text-rose-300 ring-rose-500/30",

--- a/src/components/features/influencer-shared.tsx
+++ b/src/components/features/influencer-shared.tsx
@@ -10,11 +10,11 @@ const STANCE_STYLES: Record<string, string> = {
 
 const CONSENSUS_MIXED = "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30";
 const CONSENSUS_STYLES: Record<string, string> = {
-  strong_bullish: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
+  strong_bullish: "bg-emerald-500/20 text-emerald-800 dark:text-emerald-200 ring-emerald-500/40",
   bullish: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
   mixed: CONSENSUS_MIXED,
   bearish: "bg-rose-500/10 text-rose-700 dark:text-rose-400 ring-rose-500/25",
-  strong_bearish: "bg-rose-500/20 text-rose-200 ring-rose-500/40",
+  strong_bearish: "bg-rose-500/20 text-rose-800 dark:text-rose-200 ring-rose-500/40",
 };
 
 const SENTIMENT_NEUTRAL = "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30";

--- a/src/components/features/influencer-videos.tsx
+++ b/src/components/features/influencer-videos.tsx
@@ -9,8 +9,8 @@ type Video = RouterOutputs["influencer"]["recentVideos"][number];
 type Mention = Video["mentions"][number];
 
 const STANCE_CHIP: Record<string, string> = {
-  bullish: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
-  bearish: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
+  bullish: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
+  bearish: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
   neutral: "bg-slate-500/15 text-muted-foreground ring-slate-500/30",
 };
 
@@ -24,7 +24,7 @@ function SymbolChip({ mention }: { mention: Mention }) {
 
 function VideoRow({ video }: { video: Video }) {
   return (
-    <div className="space-y-1.5 rounded-md bg-black/20 px-3 py-2.5">
+    <div className="space-y-1.5 rounded-md bg-muted px-3 py-2.5">
       <div className="flex items-center justify-between gap-2 text-xs">
         <span className="truncate font-medium text-foreground">
           {video.influencerName}

--- a/src/components/features/influencer-videos.tsx
+++ b/src/components/features/influencer-videos.tsx
@@ -11,7 +11,7 @@ type Mention = Video["mentions"][number];
 const STANCE_CHIP: Record<string, string> = {
   bullish: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
   bearish: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
-  neutral: "bg-slate-500/15 text-slate-300 ring-slate-500/30",
+  neutral: "bg-slate-500/15 text-muted-foreground ring-slate-500/30",
 };
 
 function SymbolChip({ mention }: { mention: Mention }) {
@@ -26,7 +26,7 @@ function VideoRow({ video }: { video: Video }) {
   return (
     <div className="space-y-1.5 rounded-md bg-black/20 px-3 py-2.5">
       <div className="flex items-center justify-between gap-2 text-xs">
-        <span className="truncate font-medium text-primary">
+        <span className="truncate font-medium text-foreground">
           {video.influencerName}
         </span>
         <span className="shrink-0 text-muted-foreground">
@@ -37,7 +37,7 @@ function VideoRow({ video }: { video: Video }) {
         href={video.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex items-start gap-1.5 text-sm text-gray-200 hover:text-foreground"
+        className="group flex items-start gap-1.5 text-sm text-muted-foreground hover:text-foreground"
       >
         <span className="line-clamp-2">{video.title}</span>
         <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 text-gray-600 group-hover:text-muted-foreground" />

--- a/src/components/features/influencer-videos.tsx
+++ b/src/components/features/influencer-videos.tsx
@@ -26,10 +26,10 @@ function VideoRow({ video }: { video: Video }) {
   return (
     <div className="space-y-1.5 rounded-md bg-black/20 px-3 py-2.5">
       <div className="flex items-center justify-between gap-2 text-xs">
-        <span className="truncate font-medium text-purple-200">
+        <span className="truncate font-medium text-primary">
           {video.influencerName}
         </span>
-        <span className="shrink-0 text-gray-500">
+        <span className="shrink-0 text-muted-foreground">
           {formatRelative(video.publishedAt)}
         </span>
       </div>
@@ -37,10 +37,10 @@ function VideoRow({ video }: { video: Video }) {
         href={video.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex items-start gap-1.5 text-sm text-gray-200 hover:text-white"
+        className="group flex items-start gap-1.5 text-sm text-gray-200 hover:text-foreground"
       >
         <span className="line-clamp-2">{video.title}</span>
-        <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 text-gray-600 group-hover:text-gray-400" />
+        <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 text-gray-600 group-hover:text-muted-foreground" />
       </a>
       {(video.mentions?.length ?? 0) > 0 && (
         <div className="flex flex-wrap gap-1">
@@ -55,13 +55,13 @@ function VideoRow({ video }: { video: Video }) {
 
 export function RecentInfluencerVideos({ videos }: { videos: Video[] }) {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="pb-3">
         <h2 className="text-sm font-semibold">Recently analyzed</h2>
       </CardHeader>
       <CardContent className="space-y-2">
         {videos.length === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-500">
+          <p className="py-6 text-center text-sm text-muted-foreground">
             No analyzed videos yet.
           </p>
         ) : (

--- a/src/components/features/influencer-videos.tsx
+++ b/src/components/features/influencer-videos.tsx
@@ -9,8 +9,8 @@ type Video = RouterOutputs["influencer"]["recentVideos"][number];
 type Mention = Video["mentions"][number];
 
 const STANCE_CHIP: Record<string, string> = {
-  bullish: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
-  bearish: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
+  bullish: "bg-positive-surface text-positive ring-positive/30",
+  bearish: "bg-negative-surface text-negative ring-negative/30",
   neutral: "bg-slate-500/15 text-muted-foreground ring-slate-500/30",
 };
 

--- a/src/components/features/insider-trading.tsx
+++ b/src/components/features/insider-trading.tsx
@@ -18,7 +18,7 @@ export const InsiderTrading = () => {
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <ShieldAlert className="h-4 w-4 text-orange-400" />
+          <ShieldAlert className="h-4 w-4 text-orange-700 dark:text-orange-400" />
           <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
         </div>
         <div className="flex-1 space-y-2 p-4">
@@ -41,7 +41,7 @@ export const InsiderTrading = () => {
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <ShieldAlert className="h-4 w-4 text-orange-400" />
+          <ShieldAlert className="h-4 w-4 text-orange-700 dark:text-orange-400" />
           <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
         </div>
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
@@ -63,27 +63,27 @@ export const InsiderTrading = () => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-        <ShieldAlert className="h-4 w-4 text-orange-400" />
+        <ShieldAlert className="h-4 w-4 text-orange-700 dark:text-orange-400" />
         <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
       </div>
 
       {/* Summary bar */}
       <div className="grid grid-cols-2 gap-2 border-b border-border px-4 py-2">
         <div className="rounded-md bg-green-500/10 px-3 py-1.5 text-center">
-          <div className="text-[10px] uppercase text-green-400">Buys (12m)</div>
-          <div className="font-mono text-sm font-bold text-green-300">
+          <div className="text-[10px] uppercase text-green-700 dark:text-green-400">Buys (12m)</div>
+          <div className="font-mono text-sm font-bold text-green-700 dark:text-green-400">
             {buys.length}
           </div>
-          <div className="font-mono text-[10px] text-green-400/70">
+          <div className="font-mono text-[10px] text-green-700 dark:text-green-400/70">
             ${formatLargeNumber(totalBuyValue)}
           </div>
         </div>
         <div className="rounded-md bg-red-500/10 px-3 py-1.5 text-center">
-          <div className="text-[10px] uppercase text-red-400">Sells (12m)</div>
-          <div className="font-mono text-sm font-bold text-red-300">
+          <div className="text-[10px] uppercase text-red-700 dark:text-red-400">Sells (12m)</div>
+          <div className="font-mono text-sm font-bold text-red-700 dark:text-red-400">
             {sells.length}
           </div>
-          <div className="font-mono text-[10px] text-red-400/70">
+          <div className="font-mono text-[10px] text-red-700 dark:text-red-400/70">
             ${formatLargeNumber(totalSellValue)}
           </div>
         </div>
@@ -101,9 +101,9 @@ export const InsiderTrading = () => {
             >
               <div className="mt-0.5">
                 {isBuy ? (
-                  <ArrowUpRight className="h-4 w-4 text-green-400" />
+                  <ArrowUpRight className="h-4 w-4 text-green-700 dark:text-green-400" />
                 ) : (
-                  <ArrowDownRight className="h-4 w-4 text-red-400" />
+                  <ArrowDownRight className="h-4 w-4 text-red-700 dark:text-red-400" />
                 )}
               </div>
               <div className="min-w-0 flex-1">
@@ -123,7 +123,7 @@ export const InsiderTrading = () => {
               <div className="shrink-0 text-right">
                 <div
                   className={`font-mono text-xs font-medium ${
-                    isBuy ? "text-green-400" : "text-red-400"
+                    isBuy ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"
                   }`}
                 >
                   {value > 0 ? `${isBuy ? "+" : "-"}$${formatLargeNumber(value)}` : "Unknown"}

--- a/src/components/features/insider-trading.tsx
+++ b/src/components/features/insider-trading.tsx
@@ -19,7 +19,7 @@ export const InsiderTrading = () => {
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ShieldAlert className="h-4 w-4 text-orange-400" />
-          <span className="text-sm font-semibold text-gray-200">Insider Trading</span>
+          <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
         </div>
         <div className="flex-1 space-y-2 p-4">
           {[1, 2, 3, 4, 5].map((i) => (
@@ -42,7 +42,7 @@ export const InsiderTrading = () => {
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ShieldAlert className="h-4 w-4 text-orange-400" />
-          <span className="text-sm font-semibold text-gray-200">Insider Trading</span>
+          <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
         </div>
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No insider trading data
@@ -64,7 +64,7 @@ export const InsiderTrading = () => {
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border px-4 py-2">
         <ShieldAlert className="h-4 w-4 text-orange-400" />
-        <span className="text-sm font-semibold text-gray-200">Insider Trading</span>
+        <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
       </div>
 
       {/* Summary bar */}
@@ -108,7 +108,7 @@ export const InsiderTrading = () => {
               </div>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1">
-                  <span className="truncate text-xs font-medium text-gray-200">
+                  <span className="truncate text-xs font-medium text-muted-foreground">
                     {trade.reportingName}
                   </span>
                   <span className="shrink-0 text-[10px] text-muted-foreground">

--- a/src/components/features/insider-trading.tsx
+++ b/src/components/features/insider-trading.tsx
@@ -17,19 +17,19 @@ export const InsiderTrading = () => {
   if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ShieldAlert className="h-4 w-4 text-orange-400" />
           <span className="text-sm font-semibold text-gray-200">Insider Trading</span>
         </div>
         <div className="flex-1 space-y-2 p-4">
           {[1, 2, 3, 4, 5].map((i) => (
             <div key={i} className="flex animate-pulse items-center gap-3">
-              <div className="h-6 w-6 rounded-full bg-white/10" />
+              <div className="h-6 w-6 rounded-full bg-foreground/10" />
               <div className="flex-1 space-y-1">
-                <div className="h-3 w-24 rounded bg-white/10" />
-                <div className="h-2.5 w-16 rounded bg-white/10" />
+                <div className="h-3 w-24 rounded bg-foreground/10" />
+                <div className="h-2.5 w-16 rounded bg-foreground/10" />
               </div>
-              <div className="h-3 w-14 rounded bg-white/10" />
+              <div className="h-3 w-14 rounded bg-foreground/10" />
             </div>
           ))}
         </div>
@@ -40,11 +40,11 @@ export const InsiderTrading = () => {
   if (!data?.length) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
           <ShieldAlert className="h-4 w-4 text-orange-400" />
           <span className="text-sm font-semibold text-gray-200">Insider Trading</span>
         </div>
-        <div className="flex flex-1 items-center justify-center text-sm text-gray-500">
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No insider trading data
         </div>
       </div>
@@ -62,13 +62,13 @@ export const InsiderTrading = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
         <ShieldAlert className="h-4 w-4 text-orange-400" />
         <span className="text-sm font-semibold text-gray-200">Insider Trading</span>
       </div>
 
       {/* Summary bar */}
-      <div className="grid grid-cols-2 gap-2 border-b border-white/5 px-4 py-2">
+      <div className="grid grid-cols-2 gap-2 border-b border-border px-4 py-2">
         <div className="rounded-md bg-green-500/10 px-3 py-1.5 text-center">
           <div className="text-[10px] uppercase text-green-400">Buys (12m)</div>
           <div className="font-mono text-sm font-bold text-green-300">
@@ -97,7 +97,7 @@ export const InsiderTrading = () => {
           return (
             <div
               key={`${trade.reportingName}-${trade.transactionDate}-${idx}`}
-              className="flex items-start gap-2 border-b border-white/5 px-3 py-1.5 transition-colors hover:bg-white/5"
+              className="flex items-start gap-2 border-b border-border px-3 py-1.5 transition-colors hover:bg-accent"
             >
               <div className="mt-0.5">
                 {isBuy ? (
@@ -111,11 +111,11 @@ export const InsiderTrading = () => {
                   <span className="truncate text-xs font-medium text-gray-200">
                     {trade.reportingName}
                   </span>
-                  <span className="shrink-0 text-[10px] text-gray-500">
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
                     ({trade.typeOfOwner})
                   </span>
                 </div>
-                <div className="text-[10px] text-gray-500">
+                <div className="text-[10px] text-muted-foreground">
                   {trade.transactionType} &middot;{" "}
                   {format(new Date(trade.transactionDate), "MMM d, yyyy")}
                 </div>
@@ -128,7 +128,7 @@ export const InsiderTrading = () => {
                 >
                   {value > 0 ? `${isBuy ? "+" : "-"}$${formatLargeNumber(value)}` : "Unknown"}
                 </div>
-                <div className="font-mono text-[10px] text-gray-500">
+                <div className="font-mono text-[10px] text-muted-foreground">
                   {formatLargeNumber(trade.securitiesTransacted)} @{" "}
                   {trade.price > 0 ? `$${trade.price.toFixed(2)}` : "Unknown"}
                 </div>

--- a/src/components/features/insider-trading.tsx
+++ b/src/components/features/insider-trading.tsx
@@ -18,7 +18,7 @@ export const InsiderTrading = () => {
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <ShieldAlert className="h-4 w-4 text-orange-700 dark:text-orange-400" />
+          <ShieldAlert className="h-4 w-4 text-warning" />
           <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
         </div>
         <div className="flex-1 space-y-2 p-4">
@@ -41,7 +41,7 @@ export const InsiderTrading = () => {
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <ShieldAlert className="h-4 w-4 text-orange-700 dark:text-orange-400" />
+          <ShieldAlert className="h-4 w-4 text-warning" />
           <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
         </div>
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
@@ -63,27 +63,27 @@ export const InsiderTrading = () => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-        <ShieldAlert className="h-4 w-4 text-orange-700 dark:text-orange-400" />
+        <ShieldAlert className="h-4 w-4 text-warning" />
         <span className="text-sm font-semibold text-muted-foreground">Insider Trading</span>
       </div>
 
       {/* Summary bar */}
       <div className="grid grid-cols-2 gap-2 border-b border-border px-4 py-2">
-        <div className="rounded-md bg-green-500/10 px-3 py-1.5 text-center">
-          <div className="text-[10px] uppercase text-green-700 dark:text-green-400">Buys (12m)</div>
-          <div className="font-mono text-sm font-bold text-green-700 dark:text-green-400">
+        <div className="rounded-md bg-positive-surface px-3 py-1.5 text-center">
+          <div className="text-[10px] uppercase text-positive">Buys (12m)</div>
+          <div className="font-mono text-sm font-bold text-positive">
             {buys.length}
           </div>
-          <div className="font-mono text-[10px] text-green-700 dark:text-green-400/70">
+          <div className="font-mono text-[10px] text-positive/70">
             ${formatLargeNumber(totalBuyValue)}
           </div>
         </div>
-        <div className="rounded-md bg-red-500/10 px-3 py-1.5 text-center">
-          <div className="text-[10px] uppercase text-red-700 dark:text-red-400">Sells (12m)</div>
-          <div className="font-mono text-sm font-bold text-red-700 dark:text-red-400">
+        <div className="rounded-md bg-negative-surface px-3 py-1.5 text-center">
+          <div className="text-[10px] uppercase text-negative">Sells (12m)</div>
+          <div className="font-mono text-sm font-bold text-negative">
             {sells.length}
           </div>
-          <div className="font-mono text-[10px] text-red-700 dark:text-red-400/70">
+          <div className="font-mono text-[10px] text-negative/70">
             ${formatLargeNumber(totalSellValue)}
           </div>
         </div>
@@ -101,9 +101,9 @@ export const InsiderTrading = () => {
             >
               <div className="mt-0.5">
                 {isBuy ? (
-                  <ArrowUpRight className="h-4 w-4 text-green-700 dark:text-green-400" />
+                  <ArrowUpRight className="h-4 w-4 text-positive" />
                 ) : (
-                  <ArrowDownRight className="h-4 w-4 text-red-700 dark:text-red-400" />
+                  <ArrowDownRight className="h-4 w-4 text-negative" />
                 )}
               </div>
               <div className="min-w-0 flex-1">
@@ -123,7 +123,7 @@ export const InsiderTrading = () => {
               <div className="shrink-0 text-right">
                 <div
                   className={`font-mono text-xs font-medium ${
-                    isBuy ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"
+                    isBuy ? "text-positive" : "text-negative"
                   }`}
                 >
                   {value > 0 ? `${isBuy ? "+" : "-"}$${formatLargeNumber(value)}` : "Unknown"}

--- a/src/components/features/investor-detail.tsx
+++ b/src/components/features/investor-detail.tsx
@@ -44,46 +44,46 @@ export function InvestorDetail({ slug }: { slug: string }) {
   );
 
   return (
-    <div className="min-h-screen bg-background pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-foreground">
       <div className="mx-auto max-w-5xl px-4 pt-6">
         <Link
           href="/influencers"
-          className="mb-4 inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" /> Back to Influencer Radar
         </Link>
 
         {isLoading ? (
-          <Skeleton className="h-96 w-full rounded-xl bg-white/5" />
+          <Skeleton className="h-96 w-full rounded-xl bg-foreground/5" />
         ) : !data ? (
-          <p className="py-16 text-center text-gray-400">Investor not found.</p>
+          <p className="py-16 text-center text-muted-foreground">Investor not found.</p>
         ) : (
           <>
-            <Card className="mb-4 border-white/10 bg-white/5 text-white">
+            <Card className="mb-4 border-border bg-foreground/5 text-foreground">
               <CardHeader className="flex flex-row items-start gap-4 space-y-0">
                 <Avatar className="h-14 w-14 shrink-0">
                   {data.investor.avatar && (
                     <AvatarImage src={data.investor.avatar} alt={data.investor.name} />
                   )}
-                  <AvatarFallback className="bg-purple-500/20 text-purple-200">
+                  <AvatarFallback className="bg-primary/20 text-primary">
                     {initials(data.investor.name)}
                   </AvatarFallback>
                 </Avatar>
                 <div className="min-w-0 flex-1">
                   <h1 className="text-2xl font-bold">{data.investor.name}</h1>
-                  <p className="text-sm text-gray-400">
+                  <p className="text-sm text-muted-foreground">
                     {data.investor.firm}
                     {data.investor.style ? ` · ${data.investor.style}` : ""}
                   </p>
                   {data.investor.why && (
-                    <p className="mt-2 max-w-2xl text-sm text-gray-300">{data.investor.why}</p>
+                    <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{data.investor.why}</p>
                   )}
                 </div>
                 {data.filing && (
                   <div className="shrink-0 text-right text-sm">
                     <div className="font-semibold">{formatMoney(data.filing.totalValue)}</div>
-                    <div className="text-xs text-gray-400">{data.filing.holdingsCount} holdings</div>
-                    <div className="mt-1 text-xs text-gray-500">
+                    <div className="text-xs text-muted-foreground">{data.filing.holdingsCount} holdings</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
                       {periodLabel(data.period)} · filed{" "}
                       {new Date(data.filing.filingDate).toLocaleDateString()}
                     </div>
@@ -92,45 +92,45 @@ export function InvestorDetail({ slug }: { slug: string }) {
               </CardHeader>
             </Card>
 
-            <Card className="border-white/10 bg-white/5 text-white">
+            <Card className="border-border bg-foreground/5 text-foreground">
               <CardHeader className="pb-2">
                 <h2 className="text-sm font-semibold">Holdings &amp; moves</h2>
               </CardHeader>
               <CardContent>
                 <Table>
                   <TableHeader>
-                    <TableRow className="border-white/10 hover:bg-transparent">
-                      <TableHead className="text-gray-400">Ticker</TableHead>
-                      <TableHead className="text-gray-400">Company</TableHead>
-                      <TableHead className="text-gray-400">Move</TableHead>
-                      <TableHead className="text-right text-gray-400">% Book</TableHead>
-                      <TableHead className="text-right text-gray-400">Value</TableHead>
-                      <TableHead className="text-right text-gray-400">Δ Shares</TableHead>
+                    <TableRow className="border-border hover:bg-transparent">
+                      <TableHead className="text-muted-foreground">Ticker</TableHead>
+                      <TableHead className="text-muted-foreground">Company</TableHead>
+                      <TableHead className="text-muted-foreground">Move</TableHead>
+                      <TableHead className="text-right text-muted-foreground">% Book</TableHead>
+                      <TableHead className="text-right text-muted-foreground">Value</TableHead>
+                      <TableHead className="text-right text-muted-foreground">Δ Shares</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {data.positions.map((p, i) => (
-                      <TableRow key={`${p.ticker ?? p.name}-${i}`} className="border-white/5">
+                      <TableRow key={`${p.ticker ?? p.name}-${i}`} className="border-border">
                         <TableCell className="font-semibold">
                           {p.ticker ? (
-                            <Link href={`/?symbol=${p.ticker}`} className="text-white hover:underline">
+                            <Link href={`/?symbol=${p.ticker}`} className="text-foreground hover:underline">
                               {p.ticker}
                             </Link>
                           ) : (
-                            <span className="text-gray-500">—</span>
+                            <span className="text-muted-foreground">—</span>
                           )}
                         </TableCell>
-                        <TableCell className="max-w-[220px] truncate text-gray-300">
+                        <TableCell className="max-w-[220px] truncate text-muted-foreground">
                           {p.name}
                           {p.isOption && <span className="ml-1 text-[10px] text-amber-400">OPT</span>}
                         </TableCell>
                         <TableCell>
                           <MoveBadge type={p.changeType} />
                         </TableCell>
-                        <TableCell className="text-right text-gray-300">
+                        <TableCell className="text-right text-muted-foreground">
                           {p.changeType === "sold" ? "—" : `${p.pctPortfolio.toFixed(1)}%`}
                         </TableCell>
-                        <TableCell className="text-right text-gray-300">
+                        <TableCell className="text-right text-muted-foreground">
                           {p.changeType === "sold" ? "exited" : formatMoney(p.value)}
                         </TableCell>
                         <TableCell className={`text-right ${moveColor(p.changeType)}`}>

--- a/src/components/features/investor-detail.tsx
+++ b/src/components/features/investor-detail.tsx
@@ -65,7 +65,7 @@ export function InvestorDetail({ slug }: { slug: string }) {
                   {data.investor.avatar && (
                     <AvatarImage src={data.investor.avatar} alt={data.investor.name} />
                   )}
-                  <AvatarFallback className="bg-primary/20 text-primary">
+                  <AvatarFallback className="bg-primary/20 text-foreground">
                     {initials(data.investor.name)}
                   </AvatarFallback>
                 </Avatar>

--- a/src/components/features/investor-detail.tsx
+++ b/src/components/features/investor-detail.tsx
@@ -122,7 +122,7 @@ export function InvestorDetail({ slug }: { slug: string }) {
                         </TableCell>
                         <TableCell className="max-w-[220px] truncate text-muted-foreground">
                           {p.name}
-                          {p.isOption && <span className="ml-1 text-[10px] text-amber-400">OPT</span>}
+                          {p.isOption && <span className="ml-1 text-[10px] text-amber-700 dark:text-amber-400">OPT</span>}
                         </TableCell>
                         <TableCell>
                           <MoveBadge type={p.changeType} />

--- a/src/components/features/investor-detail.tsx
+++ b/src/components/features/investor-detail.tsx
@@ -122,7 +122,7 @@ export function InvestorDetail({ slug }: { slug: string }) {
                         </TableCell>
                         <TableCell className="max-w-[220px] truncate text-muted-foreground">
                           {p.name}
-                          {p.isOption && <span className="ml-1 text-[10px] text-amber-700 dark:text-amber-400">OPT</span>}
+                          {p.isOption && <span className="ml-1 text-[10px] text-warning">OPT</span>}
                         </TableCell>
                         <TableCell>
                           <MoveBadge type={p.changeType} />

--- a/src/components/features/investor-detail.tsx
+++ b/src/components/features/investor-detail.tsx
@@ -44,7 +44,7 @@ export function InvestorDetail({ slug }: { slug: string }) {
   );
 
   return (
-    <div className="min-h-screen bg-[#15162c] pb-20 text-white">
+    <div className="min-h-screen bg-background pb-20 text-white">
       <div className="mx-auto max-w-5xl px-4 pt-6">
         <Link
           href="/influencers"

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -119,7 +119,7 @@ function TimeFrameSelector({
           className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
             value === tf
               ? "bg-foreground/10 text-foreground shadow-xs"
-              : "text-muted-foreground hover:text-gray-200"
+              : "text-muted-foreground hover:text-muted-foreground"
           }`}
         >
           {tf}
@@ -1206,7 +1206,7 @@ function NewsSummary({
   return (
     <div className="mb-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
       <div className="mb-1.5 flex items-center gap-1.5">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-foreground">
           {source === "ai" ? "AI Summary" : "Key Headlines"}
         </span>
         {status === "summarizing" && (

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -80,7 +80,7 @@ function SkeletonRows({ count = 4 }: { count?: number }) {
   return (
     <div className="flex flex-col gap-2">
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="h-6 animate-pulse rounded bg-gray-700/50" />
+        <div key={i} className="h-6 animate-pulse rounded bg-muted/50" />
       ))}
     </div>
   );
@@ -385,7 +385,7 @@ function FearGreedCard() {
           
           {/* Gauge visualization */}
           <div className="mt-3">
-            <div className="relative h-2 w-full rounded-full bg-gray-700">
+            <div className="relative h-2 w-full rounded-full bg-muted">
               {gaugeSegments.map((seg, i) => (
                 <div
                   key={i}
@@ -677,8 +677,8 @@ function IndexRow({
   if (isLoading) {
     return (
       <div className="flex items-center justify-between py-2">
-        <div className="h-5 w-32 animate-pulse rounded bg-gray-700/50" />
-        <div className="h-5 w-20 animate-pulse rounded bg-gray-700/50" />
+        <div className="h-5 w-32 animate-pulse rounded bg-muted/50" />
+        <div className="h-5 w-20 animate-pulse rounded bg-muted/50" />
       </div>
     );
   }
@@ -1260,10 +1260,10 @@ function GeneralNewsCard() {
               key={i}
               className="flex animate-pulse gap-3 border-b border-border pb-3"
             >
-              <div className="h-16 w-16 rounded bg-gray-700/50" />
+              <div className="h-16 w-16 rounded bg-muted/50" />
               <div className="flex flex-1 flex-col gap-1">
-                <div className="h-4 w-3/4 rounded bg-gray-700/50" />
-                <div className="h-3 w-1/2 rounded bg-gray-700/50" />
+                <div className="h-4 w-3/4 rounded bg-muted/50" />
+                <div className="h-3 w-1/2 rounded bg-muted/50" />
               </div>
             </div>
           ))}
@@ -1357,8 +1357,8 @@ function ForexRow({ pair, label }: { pair: string; label: string }) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-between py-2">
-        <div className="h-5 w-20 animate-pulse rounded bg-gray-700/50" />
-        <div className="h-5 w-16 animate-pulse rounded bg-gray-700/50" />
+        <div className="h-5 w-20 animate-pulse rounded bg-muted/50" />
+        <div className="h-5 w-16 animate-pulse rounded bg-muted/50" />
       </div>
     );
   }
@@ -1421,8 +1421,8 @@ function CommodityRow({ symbol, label }: { symbol: string; label: string }) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-between py-2">
-        <div className="h-5 w-20 animate-pulse rounded bg-gray-700/50" />
-        <div className="h-5 w-16 animate-pulse rounded bg-gray-700/50" />
+        <div className="h-5 w-20 animate-pulse rounded bg-muted/50" />
+        <div className="h-5 w-16 animate-pulse rounded bg-muted/50" />
       </div>
     );
   }

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -66,7 +66,7 @@ function CardShell({
 }) {
   return (
     <div
-      className={`rounded-xl border border-[#424975] bg-[#151624] p-4 ${className}`}
+      className={`rounded-xl border border-border bg-background p-4 ${className}`}
     >
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-400">
         {title}
@@ -111,7 +111,7 @@ function TimeFrameSelector({
 }) {
   const options: MacroTimeFrame[] = ["1D", "1W", "1M", "1Y"];
   return (
-    <div className="inline-flex rounded-lg border border-[#424975] bg-[#151624] p-0.5">
+    <div className="inline-flex rounded-lg border border-border bg-background p-0.5">
       {options.map((tf) => (
         <button
           key={tf}
@@ -783,7 +783,7 @@ function SectorPerformanceCard() {
               <CartesianGrid
                 horizontal={false}
                 strokeDasharray="3 3"
-                stroke="#424975"
+                stroke="var(--border-light)"
               />
               <XAxis
                 type="number"
@@ -826,7 +826,7 @@ function SectorPerformanceCard() {
         </div>
 
         {(rotation ?? trending) && (
-          <div className="mt-3 space-y-2 border-t border-[#424975] pt-3 text-xs">
+          <div className="mt-3 space-y-2 border-t border-border pt-3 text-xs">
             {rotation && (
               <>
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
@@ -979,7 +979,7 @@ function TreasuryCard() {
           <div className="h-48">
             <ResponsiveContainer>
               <LineChart data={combinedData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#424975" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-light)" />
                 <XAxis
                   dataKey="tenor"
                   fontSize={11}
@@ -1467,7 +1467,7 @@ export function MacroDashboard() {
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className="h-64 animate-pulse rounded-xl border border-[#424975] bg-[#151624]"
+            className="h-64 animate-pulse rounded-xl border border-border bg-background"
           />
         ))}
       </div>

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -200,7 +200,7 @@ function ChangeDisplay({
   const positive = changePercent >= 0;
   return (
     <span
-      className={`font-semibold ${positive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"} ${className}`}
+      className={`font-semibold ${positive ? "text-positive" : "text-negative"} ${className}`}
     >
       {positive ? "+" : ""}
       {changePercent.toFixed(2)}%
@@ -211,11 +211,11 @@ function ChangeDisplay({
 // ── Fear & Greed / VIX ─────────────────────────────────────────────
 
 const VIX_LEVELS = [
-  { max: 12, label: "Extreme Low", color: "text-green-700 dark:text-green-400" },
-  { max: 20, label: "Normal", color: "text-green-700 dark:text-green-400" },
-  { max: 25, label: "Elevated", color: "text-yellow-700 dark:text-yellow-400" },
-  { max: 30, label: "High", color: "text-orange-700 dark:text-orange-400" },
-  { max: Infinity, label: "Extreme Fear", color: "text-red-700 dark:text-red-400" },
+  { max: 12, label: "Extreme Low", color: "text-positive" },
+  { max: 20, label: "Normal", color: "text-positive" },
+  { max: 25, label: "Elevated", color: "text-warning" },
+  { max: 30, label: "High", color: "text-warning" },
+  { max: Infinity, label: "Extreme Fear", color: "text-negative" },
 ] as const;
 
 function VixCard() {
@@ -322,11 +322,11 @@ function VixCard() {
 // ── Fear & Greed Index ──────────────────────────────────────────────
 
 const FEAR_GREED_LEVELS = [
-  { max: 24, label: "Extreme Fear", color: "text-green-700 dark:text-green-400", bgColor: "bg-green-500" },
+  { max: 24, label: "Extreme Fear", color: "text-positive", bgColor: "bg-green-500" },
   { max: 44, label: "Fear", color: "text-blue-400", bgColor: "bg-blue-500" },
-  { max: 55, label: "Neutral", color: "text-yellow-700 dark:text-yellow-400", bgColor: "bg-yellow-500" },
-  { max: 75, label: "Greed", color: "text-orange-700 dark:text-orange-400", bgColor: "bg-orange-500" },
-  { max: 100, label: "Extreme Greed", color: "text-red-700 dark:text-red-400", bgColor: "bg-red-500" },
+  { max: 55, label: "Neutral", color: "text-warning", bgColor: "bg-yellow-500" },
+  { max: 75, label: "Greed", color: "text-warning", bgColor: "bg-orange-500" },
+  { max: 100, label: "Extreme Greed", color: "text-negative", bgColor: "bg-red-500" },
 ] as const;
 
 function FearGreedCard() {
@@ -418,7 +418,7 @@ function FearGreedCard() {
             </div>
             <div className="flex justify-between">
               <span>Change:</span>
-              <span className={`${data.change >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}>
+              <span className={`${data.change >= 0 ? 'text-positive' : 'text-negative'}`}>
                 {data.change >= 0 ? '+' : ''}{data.change.toFixed(1)}
               </span>
             </div>
@@ -602,8 +602,8 @@ function CarryRiskCard() {
           <div
             className={`mt-2 rounded px-2 py-1 text-[11px] font-medium ${
               nearWarning
-                ? "bg-red-500/20 text-red-700 dark:text-red-400"
-                : "bg-green-500/20 text-green-700 dark:text-green-400"
+                ? "bg-negative-surface text-negative"
+                : "bg-positive-surface text-positive"
             }`}
           >
             {nearWarning
@@ -833,7 +833,7 @@ function SectorPerformanceCard() {
                   <span className="text-muted-foreground">Money rotating into:</span>
                   {rotation.inflow.length > 0 ? (
                     rotation.inflow.map((s) => (
-                      <span key={s.name} className="text-green-700 dark:text-green-400">
+                      <span key={s.name} className="text-positive">
                         {s.name}{" "}
                         <span className="text-green-500/70">
                           {fmtPct(s.value)}
@@ -848,7 +848,7 @@ function SectorPerformanceCard() {
                   <span className="text-muted-foreground">Out of:</span>
                   {rotation.outflow.length > 0 ? (
                     rotation.outflow.map((s) => (
-                      <span key={s.name} className="text-red-700 dark:text-red-400">
+                      <span key={s.name} className="text-negative">
                         {s.name}{" "}
                         <span className="text-red-500/70">
                           {fmtPct(s.value)}
@@ -867,7 +867,7 @@ function SectorPerformanceCard() {
                   Potential trend <span className="text-muted-foreground">(1W vs 1M pace)</span>:
                 </span>
                 {trending.gaining.map((s) => (
-                  <span key={s.name} className="text-green-700 dark:text-green-400">
+                  <span key={s.name} className="text-positive">
                     ↑ {s.name}
                   </span>
                 ))}
@@ -960,8 +960,8 @@ function TreasuryCard() {
               <span
                 className={`text-lg font-semibold ${
                   spreadBps != null && spreadBps >= 0
-                    ? "text-green-700 dark:text-green-400"
-                    : "text-red-700 dark:text-red-400"
+                    ? "text-positive"
+                    : "text-negative"
                 }`}
               >
                 {spreadBps != null
@@ -972,7 +972,7 @@ function TreasuryCard() {
             </div>
           </div>
           {is2s10sInverted && (
-            <div className="mb-2 rounded bg-red-500/20 px-2 py-1 text-xs font-medium text-red-700 dark:text-red-400">
+            <div className="mb-2 rounded bg-negative-surface px-2 py-1 text-xs font-medium text-negative">
               2s/10s spread inverted — historically a recession signal
             </div>
           )}
@@ -1112,8 +1112,8 @@ function EconomicCalendarCard() {
                     <span
                       className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold ${
                         e.impact === "High"
-                          ? "bg-red-500/20 text-red-700 dark:text-red-400"
-                          : "bg-yellow-500/20 text-yellow-700 dark:text-yellow-400"
+                          ? "bg-negative-surface text-negative"
+                          : "bg-warning-surface text-warning"
                       }`}
                     >
                       {e.impact}

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -200,7 +200,7 @@ function ChangeDisplay({
   const positive = changePercent >= 0;
   return (
     <span
-      className={`font-semibold ${positive ? "text-green-400" : "text-red-400"} ${className}`}
+      className={`font-semibold ${positive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"} ${className}`}
     >
       {positive ? "+" : ""}
       {changePercent.toFixed(2)}%
@@ -211,11 +211,11 @@ function ChangeDisplay({
 // ── Fear & Greed / VIX ─────────────────────────────────────────────
 
 const VIX_LEVELS = [
-  { max: 12, label: "Extreme Low", color: "text-green-300" },
-  { max: 20, label: "Normal", color: "text-green-400" },
-  { max: 25, label: "Elevated", color: "text-yellow-400" },
-  { max: 30, label: "High", color: "text-orange-400" },
-  { max: Infinity, label: "Extreme Fear", color: "text-red-400" },
+  { max: 12, label: "Extreme Low", color: "text-green-700 dark:text-green-400" },
+  { max: 20, label: "Normal", color: "text-green-700 dark:text-green-400" },
+  { max: 25, label: "Elevated", color: "text-yellow-700 dark:text-yellow-400" },
+  { max: 30, label: "High", color: "text-orange-700 dark:text-orange-400" },
+  { max: Infinity, label: "Extreme Fear", color: "text-red-700 dark:text-red-400" },
 ] as const;
 
 function VixCard() {
@@ -322,11 +322,11 @@ function VixCard() {
 // ── Fear & Greed Index ──────────────────────────────────────────────
 
 const FEAR_GREED_LEVELS = [
-  { max: 24, label: "Extreme Fear", color: "text-green-400", bgColor: "bg-green-500" },
+  { max: 24, label: "Extreme Fear", color: "text-green-700 dark:text-green-400", bgColor: "bg-green-500" },
   { max: 44, label: "Fear", color: "text-blue-400", bgColor: "bg-blue-500" },
-  { max: 55, label: "Neutral", color: "text-yellow-400", bgColor: "bg-yellow-500" },
-  { max: 75, label: "Greed", color: "text-orange-400", bgColor: "bg-orange-500" },
-  { max: 100, label: "Extreme Greed", color: "text-red-400", bgColor: "bg-red-500" },
+  { max: 55, label: "Neutral", color: "text-yellow-700 dark:text-yellow-400", bgColor: "bg-yellow-500" },
+  { max: 75, label: "Greed", color: "text-orange-700 dark:text-orange-400", bgColor: "bg-orange-500" },
+  { max: 100, label: "Extreme Greed", color: "text-red-700 dark:text-red-400", bgColor: "bg-red-500" },
 ] as const;
 
 function FearGreedCard() {
@@ -418,7 +418,7 @@ function FearGreedCard() {
             </div>
             <div className="flex justify-between">
               <span>Change:</span>
-              <span className={`${data.change >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+              <span className={`${data.change >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}>
                 {data.change >= 0 ? '+' : ''}{data.change.toFixed(1)}
               </span>
             </div>
@@ -602,8 +602,8 @@ function CarryRiskCard() {
           <div
             className={`mt-2 rounded px-2 py-1 text-[11px] font-medium ${
               nearWarning
-                ? "bg-red-500/20 text-red-300"
-                : "bg-green-500/20 text-green-300"
+                ? "bg-red-500/20 text-red-700 dark:text-red-400"
+                : "bg-green-500/20 text-green-700 dark:text-green-400"
             }`}
           >
             {nearWarning
@@ -833,7 +833,7 @@ function SectorPerformanceCard() {
                   <span className="text-muted-foreground">Money rotating into:</span>
                   {rotation.inflow.length > 0 ? (
                     rotation.inflow.map((s) => (
-                      <span key={s.name} className="text-green-400">
+                      <span key={s.name} className="text-green-700 dark:text-green-400">
                         {s.name}{" "}
                         <span className="text-green-500/70">
                           {fmtPct(s.value)}
@@ -848,7 +848,7 @@ function SectorPerformanceCard() {
                   <span className="text-muted-foreground">Out of:</span>
                   {rotation.outflow.length > 0 ? (
                     rotation.outflow.map((s) => (
-                      <span key={s.name} className="text-red-400">
+                      <span key={s.name} className="text-red-700 dark:text-red-400">
                         {s.name}{" "}
                         <span className="text-red-500/70">
                           {fmtPct(s.value)}
@@ -867,7 +867,7 @@ function SectorPerformanceCard() {
                   Potential trend <span className="text-muted-foreground">(1W vs 1M pace)</span>:
                 </span>
                 {trending.gaining.map((s) => (
-                  <span key={s.name} className="text-green-400">
+                  <span key={s.name} className="text-green-700 dark:text-green-400">
                     ↑ {s.name}
                   </span>
                 ))}
@@ -960,8 +960,8 @@ function TreasuryCard() {
               <span
                 className={`text-lg font-semibold ${
                   spreadBps != null && spreadBps >= 0
-                    ? "text-green-400"
-                    : "text-red-400"
+                    ? "text-green-700 dark:text-green-400"
+                    : "text-red-700 dark:text-red-400"
                 }`}
               >
                 {spreadBps != null
@@ -972,7 +972,7 @@ function TreasuryCard() {
             </div>
           </div>
           {is2s10sInverted && (
-            <div className="mb-2 rounded bg-red-500/20 px-2 py-1 text-xs font-medium text-red-300">
+            <div className="mb-2 rounded bg-red-500/20 px-2 py-1 text-xs font-medium text-red-700 dark:text-red-400">
               2s/10s spread inverted — historically a recession signal
             </div>
           )}
@@ -1112,8 +1112,8 @@ function EconomicCalendarCard() {
                     <span
                       className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold ${
                         e.impact === "High"
-                          ? "bg-red-500/20 text-red-300"
-                          : "bg-yellow-500/20 text-yellow-300"
+                          ? "bg-red-500/20 text-red-700 dark:text-red-400"
+                          : "bg-yellow-500/20 text-yellow-700 dark:text-yellow-400"
                       }`}
                     >
                       {e.impact}

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -68,7 +68,7 @@ function CardShell({
     <div
       className={`rounded-xl border border-border bg-background p-4 ${className}`}
     >
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-400">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
         {title}
       </h2>
       {children}
@@ -118,8 +118,8 @@ function TimeFrameSelector({
           onClick={() => onChange(tf)}
           className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
             value === tf
-              ? "bg-white/10 text-white shadow-xs"
-              : "text-gray-400 hover:text-gray-200"
+              ? "bg-foreground/10 text-foreground shadow-xs"
+              : "text-muted-foreground hover:text-gray-200"
           }`}
         >
           {tf}
@@ -195,7 +195,7 @@ function ChangeDisplay({
   className?: string;
 }) {
   if (changePercent == null) {
-    return <span className={`text-gray-500 ${className}`}>—</span>;
+    return <span className={`text-muted-foreground ${className}`}>—</span>;
   }
   const positive = changePercent >= 0;
   return (
@@ -254,7 +254,7 @@ function VixCard() {
       ) : quote ? (
         <div>
           <div className="mb-2 flex items-baseline gap-3">
-            <span className="text-3xl font-bold text-white">
+            <span className="text-3xl font-bold text-foreground">
               {quote.price?.toFixed(2)}
             </span>
             <ChangeDisplay changePercent={changePercent} className="text-sm" />
@@ -262,7 +262,7 @@ function VixCard() {
           <span className={`text-sm font-medium ${level?.color}`}>
             {level?.label}
           </span>
-          <div className="mt-1 text-xs text-gray-500">
+          <div className="mt-1 text-xs text-muted-foreground">
             Day range: {quote.dayLow?.toFixed(2)} – {quote.dayHigh?.toFixed(2)}{" "}
             | Year: {quote.yearLow?.toFixed(2)} – {quote.yearHigh?.toFixed(2)}
           </div>
@@ -301,7 +301,7 @@ function VixCard() {
                         value: number;
                       };
                       return (
-                        <div className="rounded bg-white px-2 py-1 text-xs text-black shadow-sm">
+                        <div className="rounded bg-primary px-2 py-1 text-xs text-black shadow-sm">
                           {p.payload.date}: {p.value?.toFixed(2)}
                         </div>
                       );
@@ -313,7 +313,7 @@ function VixCard() {
           )}
         </div>
       ) : (
-        <div className="text-gray-500">No data</div>
+        <div className="text-muted-foreground">No data</div>
       )}
     </CardShell>
   );
@@ -365,7 +365,7 @@ function FearGreedCard() {
       ) : data ? (
         <div>
           <div className="mb-2 flex items-baseline gap-3">
-            <span className="text-3xl font-bold text-white">
+            <span className="text-3xl font-bold text-foreground">
               {data.value}
             </span>
             <div className="flex flex-col">
@@ -373,7 +373,7 @@ function FearGreedCard() {
                 changePercent={data.changePercentage} 
                 className="text-sm" 
               />
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-muted-foreground">
                 vs previous close
               </span>
             </div>
@@ -397,11 +397,11 @@ function FearGreedCard() {
                 />
               ))}
               <div
-                className="absolute top-1/2 h-4 w-4 -translate-y-1/2 -translate-x-1/2 rounded-full border-2 border-white bg-white shadow-lg"
+                className="absolute top-1/2 h-4 w-4 -translate-y-1/2 -translate-x-1/2 rounded-full border-2 border-border bg-primary shadow-lg"
                 style={{ left: `${data.value}%` }}
               />
             </div>
-            <div className="mt-1 flex justify-between text-xs text-gray-500">
+            <div className="mt-1 flex justify-between text-xs text-muted-foreground">
               <span>0</span>
               <span>25</span>
               <span>45</span>
@@ -411,10 +411,10 @@ function FearGreedCard() {
             </div>
           </div>
           
-          <div className="mt-3 text-xs text-gray-400">
+          <div className="mt-3 text-xs text-muted-foreground">
             <div className="flex justify-between">
               <span>Previous Close:</span>
-              <span className="text-gray-300">{data.previousClose}</span>
+              <span className="text-muted-foreground">{data.previousClose}</span>
             </div>
             <div className="flex justify-between">
               <span>Change:</span>
@@ -424,19 +424,19 @@ function FearGreedCard() {
             </div>
             <div className="flex justify-between">
               <span>Last Updated:</span>
-              <span className="text-gray-300">
+              <span className="text-muted-foreground">
                 {new Date(data.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
               </span>
             </div>
           </div>
           
-          <div className="mt-3 text-xs text-gray-500">
+          <div className="mt-3 text-xs text-muted-foreground">
             Measures market sentiment from 0 (Extreme Fear) to 100 (Extreme Greed).
             Extreme fear can indicate buying opportunities, while extreme greed may signal overbought conditions.
           </div>
         </div>
       ) : (
-        <div className="text-gray-500">No data</div>
+        <div className="text-muted-foreground">No data</div>
       )}
     </CardShell>
   );
@@ -478,16 +478,16 @@ function DollarIndexCard() {
       ) : quote ? (
         <div>
           <div className="mb-2 flex items-baseline gap-3">
-            <span className="text-3xl font-bold text-white">
+            <span className="text-3xl font-bold text-foreground">
               {quote.price?.toFixed(2)}
             </span>
             <ChangeDisplay changePercent={changePercent} className="text-sm" />
           </div>
-          <div className="text-xs text-gray-500">
+          <div className="text-xs text-muted-foreground">
             Day range: {quote.dayLow?.toFixed(2)} – {quote.dayHigh?.toFixed(2)}{" "}
             | Year: {quote.yearLow?.toFixed(2)} – {quote.yearHigh?.toFixed(2)}
           </div>
-          <div className="mt-1 text-xs text-gray-500">
+          <div className="mt-1 text-xs text-muted-foreground">
             Broad USD strength vs. a basket of major currencies — a rising
             dollar pressures commodities, EM, and US export earnings.
           </div>
@@ -526,7 +526,7 @@ function DollarIndexCard() {
                         value: number;
                       };
                       return (
-                        <div className="rounded bg-white px-2 py-1 text-xs text-black shadow-sm">
+                        <div className="rounded bg-primary px-2 py-1 text-xs text-black shadow-sm">
                           {p.payload.date}: {p.value?.toFixed(2)}
                         </div>
                       );
@@ -538,7 +538,7 @@ function DollarIndexCard() {
           )}
         </div>
       ) : (
-        <div className="text-gray-500">No data</div>
+        <div className="text-muted-foreground">No data</div>
       )}
     </CardShell>
   );
@@ -584,13 +584,13 @@ function CarryRiskCard() {
         <SkeletonRows count={3} />
       ) : (
         <div>
-          <div className="flex items-center justify-between border-b border-white/5 py-2">
+          <div className="flex items-center justify-between border-b border-border py-2">
             <div>
-              <span className="text-sm font-medium text-white">USD/JPY</span>
-              <span className="ml-2 text-xs text-gray-500">Yen Carry</span>
+              <span className="text-sm font-medium text-foreground">USD/JPY</span>
+              <span className="ml-2 text-xs text-muted-foreground">Yen Carry</span>
             </div>
             <div className="flex items-center gap-3">
-              <span className="text-sm text-gray-300">
+              <span className="text-sm text-muted-foreground">
                 ¥{jpyRate.toFixed(2)}
               </span>
               <ChangeDisplay
@@ -612,11 +612,11 @@ function CarryRiskCard() {
           </div>
           <div className="mt-2 flex items-center justify-between py-2">
             <div>
-              <span className="text-sm font-medium text-white">Bitcoin</span>
-              <span className="ml-2 text-xs text-gray-500">Risk Sentiment</span>
+              <span className="text-sm font-medium text-foreground">Bitcoin</span>
+              <span className="ml-2 text-xs text-muted-foreground">Risk Sentiment</span>
             </div>
             <div className="flex items-center gap-3">
-              <span className="text-sm text-gray-300">
+              <span className="text-sm text-muted-foreground">
                 {btcQuote?.price
                   ? `$${formatLargeNumber(btcQuote.price)}`
                   : "—"}
@@ -686,13 +686,13 @@ function IndexRow({
   if (!quote) return null;
 
   return (
-    <div className="flex items-center justify-between border-b border-white/5 py-2 last:border-0">
+    <div className="flex items-center justify-between border-b border-border py-2 last:border-0">
       <div>
-        <span className="text-sm font-medium text-white">{label}</span>
-        <span className="ml-2 text-xs text-gray-500">{region}</span>
+        <span className="text-sm font-medium text-foreground">{label}</span>
+        <span className="ml-2 text-xs text-muted-foreground">{region}</span>
       </div>
       <div className="flex items-center gap-3">
-        <span className="text-sm text-gray-300">
+        <span className="text-sm text-muted-foreground">
           {formatLargeNumber(quote.price ?? 0)}
         </span>
         <ChangeDisplay
@@ -807,7 +807,7 @@ function SectorPerformanceCard() {
                     value: number;
                   };
                   return (
-                    <div className="rounded bg-white px-2 py-1 text-xs text-black shadow-sm">
+                    <div className="rounded bg-primary px-2 py-1 text-xs text-black shadow-sm">
                       {p.payload.name}: {p.value?.toFixed(2)}%
                     </div>
                   );
@@ -830,7 +830,7 @@ function SectorPerformanceCard() {
             {rotation && (
               <>
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                  <span className="text-gray-400">Money rotating into:</span>
+                  <span className="text-muted-foreground">Money rotating into:</span>
                   {rotation.inflow.length > 0 ? (
                     rotation.inflow.map((s) => (
                       <span key={s.name} className="text-green-400">
@@ -841,11 +841,11 @@ function SectorPerformanceCard() {
                       </span>
                     ))
                   ) : (
-                    <span className="text-gray-500">—</span>
+                    <span className="text-muted-foreground">—</span>
                   )}
                 </div>
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                  <span className="text-gray-400">Out of:</span>
+                  <span className="text-muted-foreground">Out of:</span>
                   {rotation.outflow.length > 0 ? (
                     rotation.outflow.map((s) => (
                       <span key={s.name} className="text-red-400">
@@ -856,15 +856,15 @@ function SectorPerformanceCard() {
                       </span>
                     ))
                   ) : (
-                    <span className="text-gray-500">—</span>
+                    <span className="text-muted-foreground">—</span>
                   )}
                 </div>
               </>
             )}
             {trending && trending.gaining.length > 0 && (
               <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                <span className="text-gray-400">
-                  Potential trend <span className="text-gray-500">(1W vs 1M pace)</span>:
+                <span className="text-muted-foreground">
+                  Potential trend <span className="text-muted-foreground">(1W vs 1M pace)</span>:
                 </span>
                 {trending.gaining.map((s) => (
                   <span key={s.name} className="text-green-400">
@@ -872,7 +872,7 @@ function SectorPerformanceCard() {
                   </span>
                 ))}
                 {trending.fading.map((s) => (
-                  <span key={s.name} className="text-gray-500">
+                  <span key={s.name} className="text-muted-foreground">
                     ↓ {s.name}
                   </span>
                 ))}
@@ -882,7 +882,7 @@ function SectorPerformanceCard() {
         )}
         </>
       ) : (
-        <div className="text-gray-500">No data</div>
+        <div className="text-muted-foreground">No data</div>
       )}
     </CardShell>
   );
@@ -951,10 +951,10 @@ function TreasuryCard() {
         <div>
           <div className="mb-3 flex items-baseline gap-6">
             <div>
-              <span className="text-2xl font-bold text-white">
+              <span className="text-2xl font-bold text-foreground">
                 {tenYear != null ? `${tenYear.toFixed(2)}%` : "—"}
               </span>
-              <span className="ml-1.5 text-xs text-gray-500">US 10Y</span>
+              <span className="ml-1.5 text-xs text-muted-foreground">US 10Y</span>
             </div>
             <div>
               <span
@@ -968,7 +968,7 @@ function TreasuryCard() {
                   ? `${spreadBps >= 0 ? "+" : ""}${spreadBps.toFixed(0)} bps`
                   : "—"}
               </span>
-              <span className="ml-1.5 text-xs text-gray-500">2s/10s</span>
+              <span className="ml-1.5 text-xs text-muted-foreground">2s/10s</span>
             </div>
           </div>
           {is2s10sInverted && (
@@ -996,7 +996,7 @@ function TreasuryCard() {
                   content={({ payload, active, label }) => {
                     if (!active || !payload?.length) return null;
                     return (
-                      <div className="rounded bg-white px-2 py-1 text-xs text-black shadow-sm">
+                      <div className="rounded bg-primary px-2 py-1 text-xs text-black shadow-sm">
                         <div className="font-semibold">{label as string}</div>
                         {(
                           payload as {
@@ -1032,7 +1032,7 @@ function TreasuryCard() {
               </LineChart>
             </ResponsiveContainer>
           </div>
-          <div className="mt-2 flex gap-4 text-xs text-gray-400">
+          <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
             <span className="flex items-center gap-1">
               <span className="inline-block h-0.5 w-4 bg-blue-500" /> Today (
               {data?.[0]?.date})
@@ -1044,7 +1044,7 @@ function TreasuryCard() {
           </div>
         </div>
       ) : (
-        <div className="text-gray-500">No data</div>
+        <div className="text-muted-foreground">No data</div>
       )}
     </CardShell>
   );
@@ -1090,7 +1090,7 @@ function EconomicCalendarCard() {
         <div className="max-h-80 overflow-auto">
           <table className="w-full text-xs">
             <thead>
-              <tr className="border-b border-white/10 text-gray-400">
+              <tr className="border-b border-border text-muted-foreground">
                 <th className="pb-2 text-left font-medium">Date</th>
                 <th className="pb-2 text-left font-medium">Event</th>
                 <th className="pb-2 text-center font-medium">Impact</th>
@@ -1100,12 +1100,12 @@ function EconomicCalendarCard() {
             </thead>
             <tbody>
               {events.map((e, i) => (
-                <tr key={i} className="border-b border-white/5">
-                  <td className="py-1.5 text-gray-400">
+                <tr key={i} className="border-b border-border">
+                  <td className="py-1.5 text-muted-foreground">
                     {format(new Date(e.date), "MMM d")}
                   </td>
-                  <td className="py-1.5 text-white">
-                    <span className="mr-1 text-gray-500">{e.country}</span>
+                  <td className="py-1.5 text-foreground">
+                    <span className="mr-1 text-muted-foreground">{e.country}</span>
                     {e.event}
                   </td>
                   <td className="py-1.5 text-center">
@@ -1119,10 +1119,10 @@ function EconomicCalendarCard() {
                       {e.impact}
                     </span>
                   </td>
-                  <td className="py-1.5 text-right text-gray-300">
+                  <td className="py-1.5 text-right text-muted-foreground">
                     {e.estimate != null ? e.estimate : "—"}
                   </td>
-                  <td className="py-1.5 text-right text-gray-400">
+                  <td className="py-1.5 text-right text-muted-foreground">
                     {e.previous != null ? e.previous : "—"}
                   </td>
                 </tr>
@@ -1131,7 +1131,7 @@ function EconomicCalendarCard() {
           </table>
         </div>
       ) : (
-        <div className="text-gray-500">No upcoming events</div>
+        <div className="text-muted-foreground">No upcoming events</div>
       )}
     </CardShell>
   );
@@ -1204,13 +1204,13 @@ function NewsSummary({
   if (status === "idle") return null;
 
   return (
-    <div className="mb-3 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3">
+    <div className="mb-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
       <div className="mb-1.5 flex items-center gap-1.5">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-400">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
           {source === "ai" ? "AI Summary" : "Key Headlines"}
         </span>
         {status === "summarizing" && (
-          <span className="text-[10px] text-gray-500">generating...</span>
+          <span className="text-[10px] text-muted-foreground">generating...</span>
         )}
         {status === "done" && source && (
           <span className="ml-auto text-[10px] text-gray-600">
@@ -1220,12 +1220,12 @@ function NewsSummary({
       </div>
       {status === "summarizing" ? (
         <div className="space-y-1.5">
-          <div className="h-3 w-full animate-pulse rounded bg-purple-500/10" />
-          <div className="h-3 w-4/5 animate-pulse rounded bg-purple-500/10" />
-          <div className="h-3 w-3/5 animate-pulse rounded bg-purple-500/10" />
+          <div className="h-3 w-full animate-pulse rounded bg-primary/10" />
+          <div className="h-3 w-4/5 animate-pulse rounded bg-primary/10" />
+          <div className="h-3 w-3/5 animate-pulse rounded bg-primary/10" />
         </div>
       ) : (
-        <p className="whitespace-pre-line text-xs leading-relaxed text-gray-300">
+        <p className="whitespace-pre-line text-xs leading-relaxed text-muted-foreground">
           {summary}
         </p>
       )}
@@ -1258,7 +1258,7 @@ function GeneralNewsCard() {
           {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}
-              className="flex animate-pulse gap-3 border-b border-white/5 pb-3"
+              className="flex animate-pulse gap-3 border-b border-border pb-3"
             >
               <div className="h-16 w-16 rounded bg-gray-700/50" />
               <div className="flex flex-1 flex-col gap-1">
@@ -1283,7 +1283,7 @@ function GeneralNewsCard() {
                   href={article.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex gap-3 rounded-lg border-b border-white/5 pb-3 transition-colors hover:bg-white/5 last:border-0"
+                  className="flex gap-3 rounded-lg border-b border-border pb-3 transition-colors hover:bg-accent last:border-0"
                 >
                   {article.image && (
                     <div className="relative h-16 w-16 shrink-0">
@@ -1297,15 +1297,15 @@ function GeneralNewsCard() {
                     </div>
                   )}
                   <div className="flex flex-1 flex-col gap-0.5">
-                    <span className="text-sm font-medium text-white hover:underline">
+                    <span className="text-sm font-medium text-foreground hover:underline">
                       {article.title}
                     </span>
                     {article.text && (
-                      <p className="line-clamp-2 text-xs text-gray-400">
+                      <p className="line-clamp-2 text-xs text-muted-foreground">
                         {article.text}
                       </p>
                     )}
-                    <div className="flex items-center gap-2 text-[11px] text-gray-500">
+                    <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
                       <span>{article.site}</span>
                       <span>
                         {format(
@@ -1321,7 +1321,7 @@ function GeneralNewsCard() {
           </div>
         </div>
       ) : (
-        <div className="text-gray-500">No news available</div>
+        <div className="text-muted-foreground">No news available</div>
       )}
     </CardShell>
   );
@@ -1366,10 +1366,10 @@ function ForexRow({ pair, label }: { pair: string; label: string }) {
   if (!data) return null;
 
   return (
-    <div className="flex items-center justify-between border-b border-white/5 py-2 last:border-0">
-      <span className="text-sm font-medium text-white">{label}</span>
+    <div className="flex items-center justify-between border-b border-border py-2 last:border-0">
+      <span className="text-sm font-medium text-foreground">{label}</span>
       <div className="flex items-center gap-3">
-        <span className="text-sm text-gray-300">{data.bid?.toFixed(4)}</span>
+        <span className="text-sm text-muted-foreground">{data.bid?.toFixed(4)}</span>
         <ChangeDisplay
           changePercent={changePercent}
           className="min-w-[60px] text-right text-xs"
@@ -1430,10 +1430,10 @@ function CommodityRow({ symbol, label }: { symbol: string; label: string }) {
   if (!quote) return null;
 
   return (
-    <div className="flex items-center justify-between border-b border-white/5 py-2 last:border-0">
-      <span className="text-sm font-medium text-white">{label}</span>
+    <div className="flex items-center justify-between border-b border-border py-2 last:border-0">
+      <span className="text-sm font-medium text-foreground">{label}</span>
       <div className="flex items-center gap-3">
-        <span className="text-sm text-gray-300">
+        <span className="text-sm text-muted-foreground">
           ${quote.price?.toFixed(2)}
         </span>
         <ChangeDisplay
@@ -1479,7 +1479,7 @@ export function MacroDashboard() {
       <div className="p-4">
         {/* Sticky timeframe selector */}
         <div className="mb-4 flex items-center justify-between">
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-muted-foreground">
             Showing % change over selected period
           </span>
           <TimeFrameSelector value={timeFrame} onChange={setTimeFrame} />

--- a/src/components/features/market-indices.tsx
+++ b/src/components/features/market-indices.tsx
@@ -114,13 +114,13 @@ function IndexChip({ symbol, label }: { symbol: string; label: string }) {
         <MiniSparkline prices={prices} positive={positive} />
       ) : (
         <span
-          className={`text-xs ${positive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}
+          className={`text-xs ${positive ? "text-positive" : "text-negative"}`}
         >
           {positive ? "\u25B2" : "\u25BC"}
         </span>
       )}
       <span
-        className={`text-xs font-semibold ${positive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}
+        className={`text-xs font-semibold ${positive ? "text-positive" : "text-negative"}`}
       >
         {positive ? "+" : ""}
         {changePercent.toFixed(2)}%

--- a/src/components/features/market-indices.tsx
+++ b/src/components/features/market-indices.tsx
@@ -109,7 +109,7 @@ function IndexChip({ symbol, label }: { symbol: string; label: string }) {
 
   return (
     <div className="flex items-center gap-1.5">
-      <span className="text-xs font-medium text-gray-400">{label}</span>
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
       {prices.length > 1 ? (
         <MiniSparkline prices={prices} positive={positive} />
       ) : (

--- a/src/components/features/market-indices.tsx
+++ b/src/components/features/market-indices.tsx
@@ -114,13 +114,13 @@ function IndexChip({ symbol, label }: { symbol: string; label: string }) {
         <MiniSparkline prices={prices} positive={positive} />
       ) : (
         <span
-          className={`text-xs ${positive ? "text-green-400" : "text-red-400"}`}
+          className={`text-xs ${positive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}
         >
           {positive ? "\u25B2" : "\u25BC"}
         </span>
       )}
       <span
-        className={`text-xs font-semibold ${positive ? "text-green-400" : "text-red-400"}`}
+        className={`text-xs font-semibold ${positive ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}
       >
         {positive ? "+" : ""}
         {changePercent.toFixed(2)}%

--- a/src/components/features/market-indices.tsx
+++ b/src/components/features/market-indices.tsx
@@ -98,9 +98,9 @@ function IndexChip({ symbol, label }: { symbol: string; label: string }) {
   if (quoteLoading || histLoading) {
     return (
       <div className="flex animate-pulse items-center gap-1.5">
-        <div className="h-3 w-10 rounded bg-gray-700" />
-        <div className="h-5 w-12 rounded bg-gray-700" />
-        <div className="h-3 w-12 rounded bg-gray-700" />
+        <div className="h-3 w-10 rounded bg-muted" />
+        <div className="h-5 w-12 rounded bg-muted" />
+        <div className="h-3 w-12 rounded bg-muted" />
       </div>
     );
   }

--- a/src/components/features/mermaid-diagram.tsx
+++ b/src/components/features/mermaid-diagram.tsx
@@ -166,7 +166,7 @@ export function MermaidDiagram({ content }: { content: string }) {
 
   if (error) {
     return (
-      <pre className="overflow-x-auto rounded-md bg-white/10 p-3 text-sm text-red-400">
+      <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-red-400">
         {content}
       </pre>
     );
@@ -175,7 +175,7 @@ export function MermaidDiagram({ content }: { content: string }) {
   if (!svg) {
     return (
       <div className="my-2 flex justify-center">
-        <div className="h-24 w-full animate-pulse rounded bg-white/10" />
+        <div className="h-24 w-full animate-pulse rounded bg-foreground/10" />
       </div>
     );
   }

--- a/src/components/features/mermaid-diagram.tsx
+++ b/src/components/features/mermaid-diagram.tsx
@@ -166,7 +166,7 @@ export function MermaidDiagram({ content }: { content: string }) {
 
   if (error) {
     return (
-      <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-red-400">
+      <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-red-700 dark:text-red-400">
         {content}
       </pre>
     );

--- a/src/components/features/mermaid-diagram.tsx
+++ b/src/components/features/mermaid-diagram.tsx
@@ -166,7 +166,7 @@ export function MermaidDiagram({ content }: { content: string }) {
 
   if (error) {
     return (
-      <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-red-700 dark:text-red-400">
+      <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-negative">
         {content}
       </pre>
     );

--- a/src/components/features/metrics-table.tsx
+++ b/src/components/features/metrics-table.tsx
@@ -199,7 +199,7 @@ export const MetricsTable = () => {
       <div className="overflow-x-auto">
         {Object.entries(metricCategories).map(([category, metrics]) => (
           <div key={category} className="mb-8">
-            <h3 className="mb-4 text-lg font-semibold text-gray-200">
+            <h3 className="mb-4 text-lg font-semibold text-muted-foreground">
               {category} Metrics (TTM)
             </h3>
             <Table>

--- a/src/components/features/metrics-table.tsx
+++ b/src/components/features/metrics-table.tsx
@@ -205,7 +205,7 @@ export const MetricsTable = () => {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="sticky left-0 z-20 min-w-[150px] bg-[#15162c]">
+                  <TableHead className="sticky left-0 z-20 min-w-[150px] bg-background">
                     Metric
                   </TableHead>
                   {sortedResults.map((result) => (
@@ -221,7 +221,7 @@ export const MetricsTable = () => {
               <TableBody>
                 {metrics.map((metric) => (
                   <TableRow key={metric.key}>
-                    <TableCell className="sticky left-0 z-20 bg-[#15162c] font-medium">
+                    <TableCell className="sticky left-0 z-20 bg-background font-medium">
                       {metric.label}
                     </TableCell>
                     {sortedResults.map((result) => (

--- a/src/components/features/metrics-table.tsx
+++ b/src/components/features/metrics-table.tsx
@@ -174,8 +174,8 @@ export const MetricsTable = () => {
   if (isLoading) {
     return (
       <div className="h-full w-full animate-pulse space-y-4 p-4">
-        <div className="h-8 w-48 rounded bg-gray-700" />
-        <div className="h-64 rounded bg-gray-700" />
+        <div className="h-8 w-48 rounded bg-muted" />
+        <div className="h-64 rounded bg-muted" />
       </div>
     );
   }

--- a/src/components/features/navbar.tsx
+++ b/src/components/features/navbar.tsx
@@ -83,8 +83,8 @@ function NavLink({
       className={cn(
         "flex items-center gap-1.5 whitespace-nowrap rounded-lg px-2 py-2 text-sm font-medium transition-colors lg:px-3",
         isActive(href, pathname)
-          ? "bg-white/10 text-white"
-          : "text-gray-300 hover:bg-white/10 hover:text-white",
+          ? "bg-foreground/10 text-foreground"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground",
       )}
     >
       <Icon className="h-4 w-4 shrink-0" />
@@ -105,8 +105,8 @@ function MoreMenu({ pathname }: { pathname: string }) {
           className={cn(
             "flex items-center gap-1.5 whitespace-nowrap rounded-lg px-2 py-2 text-sm font-medium transition-colors lg:px-3",
             anySecondaryActive
-              ? "bg-white/10 text-white"
-              : "text-gray-300 hover:bg-white/10 hover:text-white",
+              ? "bg-foreground/10 text-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
           )}
         >
           <MoreHorizontal className="h-4 w-4 shrink-0" />
@@ -124,8 +124,8 @@ function MoreMenu({ pathname }: { pathname: string }) {
               className={cn(
                 "flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm",
                 isActive(href, pathname)
-                  ? "bg-white/10 text-white"
-                  : "text-gray-300 hover:bg-white/10 hover:text-white",
+                  ? "bg-foreground/10 text-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground",
               )}
             >
               <Icon className="h-4 w-4" />
@@ -150,8 +150,8 @@ function MobileMoreMenu({ pathname }: { pathname: string }) {
           className={cn(
             "flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs font-medium transition-colors",
             anySecondaryActive
-              ? "bg-white/10 text-white"
-              : "text-gray-300 hover:bg-white/10 hover:text-white",
+              ? "bg-foreground/10 text-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
           )}
         >
           <MoreHorizontal className="h-3.5 w-3.5" />
@@ -171,8 +171,8 @@ function MobileMoreMenu({ pathname }: { pathname: string }) {
               className={cn(
                 "flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm",
                 isActive(href, pathname)
-                  ? "bg-white/10 text-white"
-                  : "text-gray-300 hover:bg-white/10 hover:text-white",
+                  ? "bg-foreground/10 text-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground",
               )}
             >
               <Icon className="h-4 w-4" />
@@ -190,7 +190,7 @@ export function Navbar() {
   const pathname = usePathname();
 
   return (
-    <nav className="sticky top-0 z-50 border-b border-white/10 bg-background/95 px-2 py-3 backdrop-blur-xs">
+    <nav className="sticky top-0 z-50 border-b border-border bg-background/95 px-2 py-3 backdrop-blur-xs">
       {/* Row 1: Left (market indices) | Center (search, home only) | Right (nav links + auth) */}
       <div className="flex items-center">
         {/* Left: Market Indices - only on xl screens */}
@@ -206,7 +206,7 @@ export function Navbar() {
             <Search />
           </div>
         ) : (
-          <h1 className="shrink-0 text-base font-semibold text-white">
+          <h1 className="shrink-0 text-base font-semibold text-foreground">
             {getPageTitle(pathname)}
           </h1>
         )}
@@ -227,7 +227,7 @@ export function Navbar() {
           {/* Auth button */}
           <Link
             href={session ? "/api/auth/signout" : "/api/auth/signin"}
-            className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg bg-purple-500 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-600"
+            className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             {session ? (
               <LogOut className="h-4 w-4" />
@@ -250,8 +250,8 @@ export function Navbar() {
             className={cn(
               "flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs font-medium transition-colors",
               isActive(href, pathname)
-                ? "bg-white/10 text-white"
-                : "text-gray-300 hover:bg-white/10 hover:text-white",
+                ? "bg-foreground/10 text-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
             )}
           >
             <Icon className="h-3.5 w-3.5" />

--- a/src/components/features/navbar.tsx
+++ b/src/components/features/navbar.tsx
@@ -18,6 +18,7 @@ import { useSession } from "next-auth/react";
 import { cn } from "~/lib/utils";
 import { MarketIndices } from "~/components/features/market-indices";
 import { Search } from "~/components/features/search";
+import { ThemeToggle } from "~/components/theme-toggle";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -114,7 +115,7 @@ function MoreMenu({ pathname }: { pathname: string }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="w-44 border-[#424975] bg-[#1e1f36]"
+        className="w-44 border-border bg-secondary"
       >
         {secondaryLinks.map(({ href, icon: Icon, label }) => (
           <DropdownMenuItem key={href} asChild>
@@ -161,7 +162,7 @@ function MobileMoreMenu({ pathname }: { pathname: string }) {
         align="center"
         side="top"
         sideOffset={8}
-        className="w-44 border-[#424975] bg-[#1e1f36]"
+        className="w-44 border-border bg-secondary"
       >
         {secondaryLinks.map(({ href, icon: Icon, label }) => (
           <DropdownMenuItem key={href} asChild>
@@ -189,7 +190,7 @@ export function Navbar() {
   const pathname = usePathname();
 
   return (
-    <nav className="sticky top-0 z-50 border-b border-white/10 bg-[#15162c]/95 px-2 py-3 backdrop-blur-xs">
+    <nav className="sticky top-0 z-50 border-b border-white/10 bg-background/95 px-2 py-3 backdrop-blur-xs">
       {/* Row 1: Left (market indices) | Center (search, home only) | Right (nav links + auth) */}
       <div className="flex items-center">
         {/* Left: Market Indices - only on xl screens */}
@@ -219,6 +220,9 @@ export function Navbar() {
             ))}
             <MoreMenu pathname={pathname} />
           </div>
+
+          {/* Theme toggle */}
+          <ThemeToggle />
 
           {/* Auth button */}
           <Link

--- a/src/components/features/news.tsx
+++ b/src/components/features/news.tsx
@@ -113,7 +113,7 @@ const ArticleCard = ({
   source: string;
   text: string;
 }) => (
-  <div className="rounded-lg border border-gray-200 p-3 hover:bg-gray-800/50">
+  <div className="rounded-lg border border-gray-200 p-3 hover:bg-card/50">
     <div className="flex gap-3 rounded-lg">
       {images?.[0] && (
         <div className="relative h-16 w-16 shrink-0">
@@ -150,11 +150,11 @@ const ArticleCard = ({
 );
 
 const LoadingSkeleton = () => (
-  <div className="flex animate-pulse gap-4 rounded-lg border border-gray-700 p-4">
-    <div className="h-24 w-24 rounded-md bg-gray-700"></div>
+  <div className="flex animate-pulse gap-4 rounded-lg border border-border p-4">
+    <div className="h-24 w-24 rounded-md bg-muted"></div>
     <div className="flex flex-1 flex-col gap-2">
-      <div className="h-6 w-3/4 rounded bg-gray-700"></div>
-      <div className="h-4 w-1/2 rounded bg-gray-700"></div>
+      <div className="h-6 w-3/4 rounded bg-muted"></div>
+      <div className="h-4 w-1/2 rounded bg-muted"></div>
     </div>
   </div>
 );

--- a/src/components/features/news.tsx
+++ b/src/components/features/news.tsx
@@ -133,7 +133,7 @@ const ArticleCard = ({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs font-semibold text-orange-700 dark:text-orange-300 hover:underline"
+          className="text-xs font-semibold text-warning hover:underline"
           onClick={(e) => e.stopPropagation()}
         >
           {title}

--- a/src/components/features/news.tsx
+++ b/src/components/features/news.tsx
@@ -69,7 +69,7 @@ function NewsSummary({
   return (
     <div className="mb-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
       <div className="mb-1.5 flex items-center gap-1.5">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-foreground">
           {source === "ai" ? "AI Summary" : "Key Headlines"}
         </span>
         {status === "summarizing" && (

--- a/src/components/features/news.tsx
+++ b/src/components/features/news.tsx
@@ -133,7 +133,7 @@ const ArticleCard = ({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs font-semibold text-orange-50 hover:underline"
+          className="text-xs font-semibold text-orange-700 dark:text-orange-300 hover:underline"
           onClick={(e) => e.stopPropagation()}
         >
           {title}

--- a/src/components/features/news.tsx
+++ b/src/components/features/news.tsx
@@ -67,13 +67,13 @@ function NewsSummary({
   if (status === "idle") return null;
 
   return (
-    <div className="mb-3 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3">
+    <div className="mb-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
       <div className="mb-1.5 flex items-center gap-1.5">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-400">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
           {source === "ai" ? "AI Summary" : "Key Headlines"}
         </span>
         {status === "summarizing" && (
-          <span className="text-[10px] text-gray-500">generating...</span>
+          <span className="text-[10px] text-muted-foreground">generating...</span>
         )}
         {status === "done" && source && (
           <span className="ml-auto text-[10px] text-gray-600">
@@ -83,12 +83,12 @@ function NewsSummary({
       </div>
       {status === "summarizing" ? (
         <div className="space-y-1.5">
-          <div className="h-3 w-full animate-pulse rounded bg-purple-500/10" />
-          <div className="h-3 w-4/5 animate-pulse rounded bg-purple-500/10" />
-          <div className="h-3 w-3/5 animate-pulse rounded bg-purple-500/10" />
+          <div className="h-3 w-full animate-pulse rounded bg-primary/10" />
+          <div className="h-3 w-4/5 animate-pulse rounded bg-primary/10" />
+          <div className="h-3 w-3/5 animate-pulse rounded bg-primary/10" />
         </div>
       ) : (
-        <p className="whitespace-pre-line text-xs leading-relaxed text-gray-300">
+        <p className="whitespace-pre-line text-xs leading-relaxed text-muted-foreground">
           {summary}
         </p>
       )}
@@ -138,12 +138,12 @@ const ArticleCard = ({
         >
           {title}
         </a>
-        <div className="flex items-center gap-1.5 text-[11px] text-gray-400">
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
           <time>{format(new Date(date), "MMM d, h:mm a")}</time>
           <span>•</span>
           <span>{source}</span>
         </div>
-        <p className="text-[11px] leading-relaxed text-gray-300">{text}</p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground">{text}</p>
       </div>
     </div>
   </div>
@@ -189,7 +189,7 @@ export const News = () => {
   }
 
   if (!sortedResults.length) {
-    return <div className="p-4 text-gray-400">No news available</div>;
+    return <div className="p-4 text-muted-foreground">No news available</div>;
   }
 
   return (

--- a/src/components/features/pagination.tsx
+++ b/src/components/features/pagination.tsx
@@ -58,21 +58,21 @@ export function Pagination({
   if (totalPages <= 1) return null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-white/10 z-50">
+    <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-border z-50">
       <div className="container mx-auto px-2 sm:px-4">
         {/* Desktop Layout */}
         <div className="hidden md:flex items-center justify-between py-4">
           <div className="flex items-center gap-4">
-            <div className="text-sm text-gray-400">
+            <div className="text-sm text-muted-foreground">
               Showing {startItem} to {endItem} of {total} results
             </div>
             <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-400">Rows per page:</span>
+              <span className="text-sm text-muted-foreground">Rows per page:</span>
               <Select
                 value={limit.toString()}
                 onValueChange={(value) => onLimitChange(parseInt(value))}
               >
-                <SelectTrigger className="w-20 h-8 bg-white/10 border-white/20 text-white">
+                <SelectTrigger className="w-20 h-8 bg-foreground/10 border-border text-foreground">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -91,7 +91,7 @@ export function Pagination({
               size="sm"
               onClick={() => onPageChange(currentPage - 1)}
               disabled={currentPage <= 1 || isLoading}
-              className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30 disabled:bg-white/5 disabled:text-gray-400 disabled:border-white/10"
+              className="bg-foreground/10 border-border text-foreground hover:bg-accent hover:border-border disabled:bg-foreground/5 disabled:text-muted-foreground disabled:border-border"
             >
               Previous
             </Button>
@@ -100,7 +100,7 @@ export function Pagination({
               {getVisiblePages().map((page, index) => (
                 <div key={index}>
                   {page === "..." ? (
-                    <span className="px-2 py-1 text-gray-400">...</span>
+                    <span className="px-2 py-1 text-muted-foreground">...</span>
                   ) : (
                     <Button
                       variant={currentPage === page ? "default" : "outline"}
@@ -109,8 +109,8 @@ export function Pagination({
                       disabled={isLoading}
                       className={
                         currentPage === page
-                          ? "bg-white text-background hover:bg-gray-200"
-                          : "bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30"
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                          : "bg-foreground/10 border-border text-foreground hover:bg-accent hover:border-border"
                       }
                     >
                       {page}
@@ -125,7 +125,7 @@ export function Pagination({
               size="sm"
               onClick={() => onPageChange(currentPage + 1)}
               disabled={currentPage >= totalPages || isLoading}
-              className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30 disabled:bg-white/5 disabled:text-gray-400 disabled:border-white/10"
+              className="bg-foreground/10 border-border text-foreground hover:bg-accent hover:border-border disabled:bg-foreground/5 disabled:text-muted-foreground disabled:border-border"
             >
               Next
             </Button>
@@ -135,16 +135,16 @@ export function Pagination({
         {/* Mobile Layout */}
         <div className="md:hidden py-3 space-y-3">
           <div className="flex items-center justify-between">
-            <div className="text-xs text-gray-400">
+            <div className="text-xs text-muted-foreground">
               {startItem}-{endItem} of {total}
             </div>
             <div className="flex items-center gap-1">
-              <span className="text-xs text-gray-400">Per page:</span>
+              <span className="text-xs text-muted-foreground">Per page:</span>
               <Select
                 value={limit.toString()}
                 onValueChange={(value) => onLimitChange(parseInt(value))}
               >
-                <SelectTrigger className="w-16 h-7 bg-white/10 border-white/20 text-white text-xs">
+                <SelectTrigger className="w-16 h-7 bg-foreground/10 border-border text-foreground text-xs">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -163,7 +163,7 @@ export function Pagination({
               size="sm"
               onClick={() => onPageChange(currentPage - 1)}
               disabled={currentPage <= 1 || isLoading}
-              className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30 disabled:bg-white/5 disabled:text-gray-400 disabled:border-white/10 text-xs px-2 h-7"
+              className="bg-foreground/10 border-border text-foreground hover:bg-accent hover:border-border disabled:bg-foreground/5 disabled:text-muted-foreground disabled:border-border text-xs px-2 h-7"
             >
               Prev
             </Button>
@@ -172,7 +172,7 @@ export function Pagination({
               {getVisiblePages().slice(0, 5).map((page, index) => (
                 <div key={index}>
                   {page === "..." ? (
-                    <span className="px-1 text-gray-400 text-xs">...</span>
+                    <span className="px-1 text-muted-foreground text-xs">...</span>
                   ) : (
                     <Button
                       variant={currentPage === page ? "default" : "outline"}
@@ -181,8 +181,8 @@ export function Pagination({
                       disabled={isLoading}
                       className={
                         currentPage === page
-                          ? "bg-white text-background hover:bg-gray-200 text-xs px-2 h-7 min-w-7"
-                          : "bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30 text-xs px-2 h-7 min-w-7"
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90 text-xs px-2 h-7 min-w-7"
+                          : "bg-foreground/10 border-border text-foreground hover:bg-accent hover:border-border text-xs px-2 h-7 min-w-7"
                       }
                     >
                       {page}
@@ -197,7 +197,7 @@ export function Pagination({
               size="sm"
               onClick={() => onPageChange(currentPage + 1)}
               disabled={currentPage >= totalPages || isLoading}
-              className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30 disabled:bg-white/5 disabled:text-gray-400 disabled:border-white/10 text-xs px-2 h-7"
+              className="bg-foreground/10 border-border text-foreground hover:bg-accent hover:border-border disabled:bg-foreground/5 disabled:text-muted-foreground disabled:border-border text-xs px-2 h-7"
             >
               Next
             </Button>

--- a/src/components/features/pagination.tsx
+++ b/src/components/features/pagination.tsx
@@ -58,7 +58,7 @@ export function Pagination({
   if (totalPages <= 1) return null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-[#15162c] border-t border-white/10 z-50">
+    <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-white/10 z-50">
       <div className="container mx-auto px-2 sm:px-4">
         {/* Desktop Layout */}
         <div className="hidden md:flex items-center justify-between py-4">
@@ -109,7 +109,7 @@ export function Pagination({
                       disabled={isLoading}
                       className={
                         currentPage === page
-                          ? "bg-white text-[#15162c] hover:bg-gray-200"
+                          ? "bg-white text-background hover:bg-gray-200"
                           : "bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30"
                       }
                     >
@@ -181,7 +181,7 @@ export function Pagination({
                       disabled={isLoading}
                       className={
                         currentPage === page
-                          ? "bg-white text-[#15162c] hover:bg-gray-200 text-xs px-2 h-7 min-w-7"
+                          ? "bg-white text-background hover:bg-gray-200 text-xs px-2 h-7 min-w-7"
                           : "bg-white/10 border-white/20 text-white hover:bg-white/20 hover:border-white/30 text-xs px-2 h-7 min-w-7"
                       }
                     >

--- a/src/components/features/quote.tsx
+++ b/src/components/features/quote.tsx
@@ -11,7 +11,7 @@ export const QuoteMetrics = ({ data }: { data: EquityQuoteItem }) => {
   return (
     <div className="grid gap-4 p-4">
       {/* Price Metrics */}
-      <Card className="bg-transparent p-4 text-gray-50">
+      <Card className="bg-transparent p-4 text-muted-foreground">
         <h3 className="mb-3 flex items-center text-sm font-semibold">
           <DollarSign className="mr-2 h-5 w-5" />
           Price Metrics
@@ -46,7 +46,7 @@ export const QuoteMetrics = ({ data }: { data: EquityQuoteItem }) => {
       </Card>
 
       {/* Volume Metrics */}
-      <Card className="bg-transparent p-4 text-gray-50">
+      <Card className="bg-transparent p-4 text-muted-foreground">
         <h3 className="mb-3 flex items-center text-sm font-semibold">
           <BarChart className="mr-2 h-5 w-5" />
           Volume Metrics
@@ -78,7 +78,7 @@ export const QuoteMetrics = ({ data }: { data: EquityQuoteItem }) => {
       </Card>
 
       {/* Trading Metrics */}
-      <Card className="bg-transparent p-4 text-gray-50">
+      <Card className="bg-transparent p-4 text-muted-foreground">
         <h3 className="mb-3 flex items-center text-sm font-semibold">
           <TrendingUp className="mr-2 h-5 w-5" />
           Trading Metrics

--- a/src/components/features/revenue.tsx
+++ b/src/components/features/revenue.tsx
@@ -40,7 +40,7 @@ interface CustomTooltipProps {
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (active && payload?.length) {
     return (
-      <div className="rounded-lg border bg-white p-4 shadow-xs">
+      <div className="rounded-lg border bg-primary p-4 shadow-xs">
         <p className="mb-2 font-medium">{formatQuarter(label)}</p>
         {payload.map((entry) => (
           <p key={entry.name} style={{ color: entry.fill ?? entry.stroke }}>

--- a/src/components/features/revenue.tsx
+++ b/src/components/features/revenue.tsx
@@ -76,7 +76,7 @@ export const HistoricalRevenue = () => {
 
   return (
     <div>
-      <h2 className="mt-2 text-center text-xl font-semibold text-gray-200">
+      <h2 className="mt-2 text-center text-xl font-semibold text-muted-foreground">
         Revenue
       </h2>
       <ResponsiveContainer height={500}>

--- a/src/components/features/screener-filters.tsx
+++ b/src/components/features/screener-filters.tsx
@@ -52,10 +52,10 @@ export function ScreenerFilters({
   return (
     <div className="mb-6">
       {/* Desktop Layout */}
-      <div className="hidden rounded-lg bg-white/5 p-4 md:block">
+      <div className="hidden rounded-lg bg-foreground/5 p-4 md:block">
         <div className="grid grid-cols-1 items-end gap-4 md:grid-cols-2 lg:grid-cols-5">
           <div className="space-y-2">
-            <Label htmlFor="sector" className="text-white">
+            <Label htmlFor="sector" className="text-foreground">
               Sector
             </Label>
             <Select value={sector} onValueChange={onSectorChange}>
@@ -84,7 +84,7 @@ export function ScreenerFilters({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="recommendation" className="text-white">
+            <Label htmlFor="recommendation" className="text-foreground">
               Recommendation
             </Label>
             <Select
@@ -105,7 +105,7 @@ export function ScreenerFilters({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="marketCapMin" className="text-white">
+            <Label htmlFor="marketCapMin" className="text-foreground">
               Min Market Cap ($M)
             </Label>
             <Input
@@ -118,7 +118,7 @@ export function ScreenerFilters({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="marketCapMax" className="text-white">
+            <Label htmlFor="marketCapMax" className="text-foreground">
               Max Market Cap ($M)
             </Label>
             <Input
@@ -133,7 +133,7 @@ export function ScreenerFilters({
           <Button
             variant="outline"
             onClick={onClearFilters}
-            className="h-10 border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+            className="h-10 border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent"
           >
             Clear Filters
           </Button>
@@ -146,13 +146,13 @@ export function ScreenerFilters({
           <CollapsibleTrigger asChild>
             <Button
               variant="outline"
-              className="w-full justify-between border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+              className="w-full justify-between border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent"
             >
               <div className="flex items-center gap-2">
                 <Filter className="h-4 w-4" />
                 <span>Filters</span>
                 {hasActiveFilters && (
-                  <span className="rounded-full bg-blue-500 px-2 py-0.5 text-xs text-white">
+                  <span className="rounded-full bg-blue-500 px-2 py-0.5 text-xs text-foreground">
                     Active
                   </span>
                 )}
@@ -166,9 +166,9 @@ export function ScreenerFilters({
           </CollapsibleTrigger>
 
           <CollapsibleContent className="mt-4">
-            <div className="space-y-4 rounded-lg bg-white/5 p-4">
+            <div className="space-y-4 rounded-lg bg-foreground/5 p-4">
               <div className="space-y-2">
-                <Label htmlFor="sector-mobile" className="text-white">
+                <Label htmlFor="sector-mobile" className="text-foreground">
                   Sector
                 </Label>
                 <Select value={sector} onValueChange={onSectorChange}>
@@ -197,7 +197,7 @@ export function ScreenerFilters({
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="recommendation-mobile" className="text-white">
+                <Label htmlFor="recommendation-mobile" className="text-foreground">
                   Recommendation
                 </Label>
                 <Select
@@ -219,7 +219,7 @@ export function ScreenerFilters({
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="marketCapMin-mobile" className="text-white">
+                  <Label htmlFor="marketCapMin-mobile" className="text-foreground">
                     Min Cap ($M)
                   </Label>
                   <Input
@@ -232,7 +232,7 @@ export function ScreenerFilters({
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="marketCapMax-mobile" className="text-white">
+                  <Label htmlFor="marketCapMax-mobile" className="text-foreground">
                     Max Cap ($M)
                   </Label>
                   <Input
@@ -248,7 +248,7 @@ export function ScreenerFilters({
               <Button
                 variant="outline"
                 onClick={onClearFilters}
-                className="w-full border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+                className="w-full border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent"
               >
                 Clear Filters
               </Button>

--- a/src/components/features/screener-table.tsx
+++ b/src/components/features/screener-table.tsx
@@ -48,15 +48,15 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
   const getRecommendationColor = (recommendation: string | null) => {
     switch (recommendation) {
       case "strong_buy":
-        return "border-transparent bg-emerald-500/20 text-emerald-800 ring-1 ring-inset ring-emerald-500/40 hover:bg-emerald-500/30 dark:text-emerald-200";
+        return "border-transparent bg-positive-surface text-positive ring-1 ring-inset ring-positive/30 hover:bg-positive-surface";
       case "buy":
-        return "border-transparent bg-emerald-500/15 text-emerald-700 ring-1 ring-inset ring-emerald-500/30 hover:bg-emerald-500/25 dark:text-emerald-400";
+        return "border-transparent bg-positive-surface text-positive ring-1 ring-inset ring-positive/30 hover:bg-positive-surface";
       case "hold":
-        return "border-transparent bg-amber-500/15 text-amber-700 ring-1 ring-inset ring-amber-500/30 hover:bg-amber-500/25 dark:text-amber-400";
+        return "border-transparent bg-warning-surface text-warning ring-1 ring-inset ring-warning/30 hover:bg-warning-surface";
       case "sell":
-        return "border-transparent bg-rose-500/15 text-rose-700 ring-1 ring-inset ring-rose-500/30 hover:bg-rose-500/25 dark:text-rose-400";
+        return "border-transparent bg-negative-surface text-negative ring-1 ring-inset ring-negative/30 hover:bg-negative-surface";
       case "strong_sell":
-        return "border-transparent bg-rose-500/20 text-rose-800 ring-1 ring-inset ring-rose-500/40 hover:bg-rose-500/30 dark:text-rose-200";
+        return "border-transparent bg-negative-surface text-negative ring-1 ring-inset ring-negative/30 hover:bg-negative-surface";
       default:
         return "border-transparent bg-muted text-muted-foreground ring-1 ring-inset ring-border";
     }

--- a/src/components/features/screener-table.tsx
+++ b/src/components/features/screener-table.tsx
@@ -48,15 +48,17 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
   const getRecommendationColor = (recommendation: string | null) => {
     switch (recommendation) {
       case "strong_buy":
-        return "bg-green-500 hover:bg-green-600";
+        return "border-transparent bg-emerald-500/20 text-emerald-800 ring-1 ring-inset ring-emerald-500/40 hover:bg-emerald-500/30 dark:text-emerald-200";
       case "buy":
-        return "bg-green-400 hover:bg-green-500";
+        return "border-transparent bg-emerald-500/15 text-emerald-700 ring-1 ring-inset ring-emerald-500/30 hover:bg-emerald-500/25 dark:text-emerald-400";
       case "hold":
-        return "bg-yellow-500 hover:bg-yellow-600";
+        return "border-transparent bg-amber-500/15 text-amber-700 ring-1 ring-inset ring-amber-500/30 hover:bg-amber-500/25 dark:text-amber-400";
       case "sell":
-        return "bg-red-500 hover:bg-red-600";
+        return "border-transparent bg-rose-500/15 text-rose-700 ring-1 ring-inset ring-rose-500/30 hover:bg-rose-500/25 dark:text-rose-400";
+      case "strong_sell":
+        return "border-transparent bg-rose-500/20 text-rose-800 ring-1 ring-inset ring-rose-500/40 hover:bg-rose-500/30 dark:text-rose-200";
       default:
-        return "bg-gray-500 hover:bg-muted";
+        return "border-transparent bg-muted text-muted-foreground ring-1 ring-inset ring-border";
     }
   };
 

--- a/src/components/features/screener-table.tsx
+++ b/src/components/features/screener-table.tsx
@@ -89,7 +89,7 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
   if (stocks.length === 0) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="text-lg text-gray-400">
+        <div className="text-lg text-muted-foreground">
           No stocks found matching your criteria.
         </div>
       </div>
@@ -98,30 +98,30 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
 
   return (
     <>
-      <div className="overflow-hidden rounded-lg border border-white/10">
+      <div className="overflow-hidden rounded-lg border border-border">
         <div className="max-h-[calc(100vh-300px)] overflow-y-auto">
           <Table>
             <TableHeader className="sticky top-0 z-10 bg-background">
-              <TableRow className="border-white/10 hover:bg-white/5">
-                <TableHead className="bg-background text-white">
+              <TableRow className="border-border hover:bg-accent">
+                <TableHead className="bg-background text-foreground">
                   Symbol
                 </TableHead>
-                <TableHead className="bg-background text-white">
+                <TableHead className="bg-background text-foreground">
                   Sector
                 </TableHead>
-                <TableHead className="bg-background text-white">
+                <TableHead className="bg-background text-foreground">
                   Market Cap
                 </TableHead>
-                <TableHead className="bg-background text-white">
+                <TableHead className="bg-background text-foreground">
                   Recommendation
                 </TableHead>
-                <TableHead className="bg-background text-white">
+                <TableHead className="bg-background text-foreground">
                   Report
                 </TableHead>
-                <TableHead className="bg-background text-white">
+                <TableHead className="bg-background text-foreground">
                   Last Updated
                 </TableHead>
-                <TableHead className="bg-background text-white">
+                <TableHead className="bg-background text-foreground">
                   Stock details
                 </TableHead>
               </TableRow>
@@ -130,15 +130,15 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
               {stocks.map((stock) => (
                 <TableRow
                   key={stock.supabaseId}
-                  className="border-white/10 hover:bg-white/5"
+                  className="border-border hover:bg-accent"
                 >
-                  <TableCell className="font-medium text-white">
+                  <TableCell className="font-medium text-foreground">
                     {stock.supabaseId}
                   </TableCell>
-                  <TableCell className="text-gray-300">
+                  <TableCell className="text-muted-foreground">
                     {stock.sector ?? "N/A"}
                   </TableCell>
-                  <TableCell className="text-gray-300">
+                  <TableCell className="text-muted-foreground">
                     {formatMarketCap(stock.marketCap ?? null)}
                   </TableCell>
                   <TableCell>
@@ -154,12 +154,12 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
                       size="sm"
                       onClick={() => handleViewReport(stock)}
                       disabled={!stock.response}
-                      className="border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20 disabled:border-white/10 disabled:bg-white/5 disabled:text-gray-400"
+                      className="border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent disabled:border-border disabled:bg-foreground/5 disabled:text-muted-foreground"
                     >
                       {stock.response ? "View Report" : "No Report"}
                     </Button>
                   </TableCell>
-                  <TableCell className="text-gray-300">
+                  <TableCell className="text-muted-foreground">
                     {stock.createdAt
                       ? new Date(stock.createdAt).toLocaleDateString()
                       : "N/A"}
@@ -169,7 +169,7 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
                       variant="outline"
                       size="sm"
                       onClick={() => handleSelectStock(stock.supabaseId)}
-                      className="border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+                      className="border-border bg-foreground/10 text-foreground hover:border-border hover:bg-accent"
                     >
                       <ArrowRight className="h-4 w-4" />
                     </Button>

--- a/src/components/features/screener-table.tsx
+++ b/src/components/features/screener-table.tsx
@@ -56,7 +56,7 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
       case "sell":
         return "bg-red-500 hover:bg-red-600";
       default:
-        return "bg-gray-500 hover:bg-gray-600";
+        return "bg-gray-500 hover:bg-muted";
     }
   };
 

--- a/src/components/features/screener-table.tsx
+++ b/src/components/features/screener-table.tsx
@@ -101,27 +101,27 @@ export function ScreenerTable({ stocks, isLoading }: ScreenerTableProps) {
       <div className="overflow-hidden rounded-lg border border-white/10">
         <div className="max-h-[calc(100vh-300px)] overflow-y-auto">
           <Table>
-            <TableHeader className="sticky top-0 z-10 bg-[#15162c]">
+            <TableHeader className="sticky top-0 z-10 bg-background">
               <TableRow className="border-white/10 hover:bg-white/5">
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Symbol
                 </TableHead>
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Sector
                 </TableHead>
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Market Cap
                 </TableHead>
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Recommendation
                 </TableHead>
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Report
                 </TableHead>
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Last Updated
                 </TableHead>
-                <TableHead className="bg-[#15162c] text-white">
+                <TableHead className="bg-background text-white">
                   Stock details
                 </TableHead>
               </TableRow>

--- a/src/components/features/search.tsx
+++ b/src/components/features/search.tsx
@@ -69,7 +69,7 @@ export function Search() {
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="justify-between border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white"
+          className="justify-between border-border bg-foreground/10 text-foreground hover:bg-accent hover:text-foreground"
         >
           <p className="w-32 overflow-hidden text-ellipsis whitespace-nowrap sm:w-64">
             {stocks && !!symbol && !open
@@ -81,9 +81,9 @@ export function Search() {
           </p>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="border-white/10 bg-background p-0 text-white">
+      <PopoverContent className="border-border bg-background p-0 text-foreground">
         <Command
-          className="bg-background text-white"
+          className="bg-background text-foreground"
           shouldFilter={
             !!isReady && !!stocks?.length && !!debouncedSearch?.length
           }
@@ -101,8 +101,8 @@ export function Search() {
         >
           <CommandInput
             placeholder="Search stock..."
-            className="h-9 text-white placeholder:text-white/50"
-            containerClassName="border-white/10"
+            className="h-9 text-foreground placeholder:text-foreground/50"
+            containerClassName="border-border"
             value={search}
             onValueChange={(value) => setSearch(value)}
           />
@@ -122,7 +122,7 @@ export function Search() {
                       key={stock.value}
                       value={stock.value}
                       keywords={[stock.value, stock.label]}
-                      className="text-white hover:bg-white/10 aria-selected:bg-white/10"
+                      className="text-foreground hover:bg-accent aria-selected:bg-foreground/10"
                       onSelect={(currentValue) => {
                         setSymbol(currentValue);
 

--- a/src/components/features/search.tsx
+++ b/src/components/features/search.tsx
@@ -81,9 +81,9 @@ export function Search() {
           </p>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="border-white/10 bg-[#15162c] p-0 text-white">
+      <PopoverContent className="border-white/10 bg-background p-0 text-white">
         <Command
-          className="bg-[#15162c] text-white"
+          className="bg-background text-white"
           shouldFilter={
             !!isReady && !!stocks?.length && !!debouncedSearch?.length
           }

--- a/src/components/features/stock-comparison.tsx
+++ b/src/components/features/stock-comparison.tsx
@@ -515,11 +515,11 @@ function StockSearchPopover({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[300px] border-white/10 bg-[#15162c] p-0 text-white"
+        className="w-[300px] border-white/10 bg-background p-0 text-white"
         align="start"
       >
         <Command
-          className="bg-[#15162c] text-white"
+          className="bg-background text-white"
           shouldFilter={
             !!isReady && !!stocks?.length && !!debouncedSearch?.length
           }
@@ -981,7 +981,7 @@ export function StockComparison() {
                             key={metric.key}
                             className="border-b border-white/5 transition-colors hover:bg-white/2"
                           >
-                            <td className="sticky left-0 z-10 bg-[#15162c] px-4 py-2 text-xs text-gray-300">
+                            <td className="sticky left-0 z-10 bg-background px-4 py-2 text-xs text-gray-300">
                               <div className="flex items-center gap-1">
                                 {metric.label}
                               </div>
@@ -1082,7 +1082,7 @@ export function StockComparison() {
                       key={row.label}
                       className="border-b border-white/5 transition-colors hover:bg-white/2"
                     >
-                      <td className="sticky left-0 z-10 bg-[#15162c] px-4 py-2 text-xs text-gray-300">
+                      <td className="sticky left-0 z-10 bg-background px-4 py-2 text-xs text-gray-300">
                         {row.label}
                       </td>
                       {symbols.map((s, i) =>

--- a/src/components/features/stock-comparison.tsx
+++ b/src/components/features/stock-comparison.tsx
@@ -627,7 +627,7 @@ function StockHeader({
           onError={() => setImgFailed(true)}
         />
       ) : (
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/20 text-sm font-bold text-primary">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/20 text-sm font-bold text-foreground">
           {stock.symbol.slice(0, 2)}
         </div>
       )}
@@ -636,7 +636,7 @@ function StockHeader({
         {stock.name}
       </span>
       <div className="flex items-center gap-1">
-        <span className="font-mono text-xs text-gray-200">
+        <span className="font-mono text-xs text-muted-foreground">
           ${stock.price.toFixed(2)}
         </span>
         <span
@@ -677,7 +677,7 @@ function MetricCell({
   const isGrowth = formatted.startsWith("+") || formatted.startsWith("-");
   const isNeg = value != null && value < 0;
 
-  let textColor = "text-gray-200";
+  let textColor = "text-muted-foreground";
   if (better !== "neutral" && isBest) textColor = "text-green-400";
   if (better !== "neutral" && isWorst) textColor = "text-red-400";
   if (better === "neutral" && isGrowth) {
@@ -733,8 +733,8 @@ function SuggestedPeers({
   return (
     <div className="rounded-xl border border-border bg-foreground/5 p-4">
       <div className="mb-3 flex items-center gap-2">
-        <Users className="h-4 w-4 text-primary" />
-        <span className="text-sm font-semibold text-gray-200">
+        <Users className="h-4 w-4 text-foreground" />
+        <span className="text-sm font-semibold text-muted-foreground">
           Suggested Competitors
         </span>
       </div>
@@ -927,10 +927,10 @@ export function StockComparison() {
                         className="sticky left-0 z-10 px-4 py-2.5"
                       >
                         <div className="flex items-center gap-2">
-                          <span className="text-primary">
+                          <span className="text-foreground">
                             {section.icon}
                           </span>
-                          <span className="text-sm font-semibold text-primary">
+                          <span className="text-sm font-semibold text-foreground">
                             {section.title}
                           </span>
                           {isCollapsed ? (
@@ -1020,8 +1020,8 @@ export function StockComparison() {
                   className="sticky left-0 z-10 px-4 py-2.5"
                 >
                   <div className="flex items-center gap-2">
-                    <BarChart3 className="h-4 w-4 text-primary" />
-                    <span className="text-sm font-semibold text-primary">
+                    <BarChart3 className="h-4 w-4 text-foreground" />
+                    <span className="text-sm font-semibold text-foreground">
                       Market Data
                     </span>
                     {collapsedSections.has("__market") ? (
@@ -1090,7 +1090,7 @@ export function StockComparison() {
                           <td
                             key={s}
                             className={cn(
-                              "px-3 py-2 text-center font-mono text-sm text-gray-200",
+                              "px-3 py-2 text-center font-mono text-sm text-muted-foreground",
                               row.className,
                             )}
                           >

--- a/src/components/features/stock-comparison.tsx
+++ b/src/components/features/stock-comparison.tsx
@@ -896,7 +896,7 @@ export function StockComparison() {
           <table className="w-full">
             <thead>
               <tr className="border-b border-border bg-foreground/5">
-                <th className="sticky left-0 z-10 min-w-[200px] bg-[#1a1b35] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                <th className="sticky left-0 z-10 min-w-[200px] bg-card px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Metric
                 </th>
                 {symbols.map((s) => (

--- a/src/components/features/stock-comparison.tsx
+++ b/src/components/features/stock-comparison.tsx
@@ -509,17 +509,17 @@ function StockSearchPopover({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button className="flex h-full min-h-[120px] w-[180px] flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-white/20 transition-all hover:border-purple-400/60 hover:bg-white/5">
-          <Plus className="h-6 w-6 text-gray-400" />
-          <span className="text-xs text-gray-400">Add Stock</span>
+        <button className="flex h-full min-h-[120px] w-[180px] flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border transition-all hover:border-primary/60 hover:bg-accent">
+          <Plus className="h-6 w-6 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground">Add Stock</span>
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[300px] border-white/10 bg-background p-0 text-white"
+        className="w-[300px] border-border bg-background p-0 text-foreground"
         align="start"
       >
         <Command
-          className="bg-background text-white"
+          className="bg-background text-foreground"
           shouldFilter={
             !!isReady && !!stocks?.length && !!debouncedSearch?.length
           }
@@ -535,8 +535,8 @@ function StockSearchPopover({
         >
           <CommandInput
             placeholder="Search stocks..."
-            className="h-9 text-white placeholder:text-white/50"
-            containerClassName="border-white/10"
+            className="h-9 text-foreground placeholder:text-foreground/50"
+            containerClassName="border-border"
             value={search}
             onValueChange={setSearch}
           />
@@ -545,7 +545,7 @@ function StockSearchPopover({
             {isLoading ? (
               <CommandLoading>
                 <div className="flex justify-center py-6">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-purple-400 border-t-transparent" />
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
                 </div>
               </CommandLoading>
             ) : (
@@ -555,7 +555,7 @@ function StockSearchPopover({
                     key={stock.value}
                     value={stock.value}
                     keywords={[stock.value, stock.label]}
-                    className="text-white hover:bg-white/10 aria-selected:bg-white/10"
+                    className="text-foreground hover:bg-accent aria-selected:bg-foreground/10"
                     onSelect={(val) => {
                       onSelect(val.toUpperCase());
                       setOpen(false);
@@ -578,13 +578,13 @@ function StockSearchPopover({
 
 function StockHeaderSkeleton() {
   return (
-    <div className="flex w-[180px] animate-pulse flex-col items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-4">
-      <div className="h-10 w-10 rounded-lg bg-white/10" />
-      <div className="h-4 w-12 rounded bg-white/10" />
-      <div className="h-3 w-20 rounded bg-white/10" />
-      <div className="h-3 w-24 rounded bg-white/10" />
-      <div className="h-3 w-14 rounded bg-white/10" />
-      <div className="h-3 w-20 rounded bg-white/10" />
+    <div className="flex w-[180px] animate-pulse flex-col items-center gap-2 rounded-xl border border-border bg-foreground/5 px-3 py-4">
+      <div className="h-10 w-10 rounded-lg bg-foreground/10" />
+      <div className="h-4 w-12 rounded bg-foreground/10" />
+      <div className="h-3 w-20 rounded bg-foreground/10" />
+      <div className="h-3 w-24 rounded bg-foreground/10" />
+      <div className="h-3 w-14 rounded bg-foreground/10" />
+      <div className="h-3 w-20 rounded bg-foreground/10" />
     </div>
   );
 }
@@ -594,7 +594,7 @@ function StockHeaderSkeleton() {
 function MetricCellSkeleton() {
   return (
     <td className="px-3 py-2 text-center">
-      <div className="mx-auto h-5 w-16 animate-pulse rounded bg-white/10" />
+      <div className="mx-auto h-5 w-16 animate-pulse rounded bg-foreground/10" />
     </td>
   );
 }
@@ -610,10 +610,10 @@ function StockHeader({
 }) {
   const [imgFailed, setImgFailed] = useState(false);
   return (
-    <div className="group relative flex w-[180px] flex-col items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-4 transition-all hover:border-purple-400/30">
+    <div className="group relative flex w-[180px] flex-col items-center gap-2 rounded-xl border border-border bg-foreground/5 px-3 py-4 transition-all hover:border-primary/30">
       <button
         onClick={onRemove}
-        className="absolute -right-2 -top-2 hidden rounded-full bg-red-500/90 p-1 text-white transition-all hover:bg-red-400 group-hover:block"
+        className="absolute -right-2 -top-2 hidden rounded-full bg-red-500/90 p-1 text-foreground transition-all hover:bg-red-400 group-hover:block"
       >
         <X className="h-3 w-3" />
       </button>
@@ -627,12 +627,12 @@ function StockHeader({
           onError={() => setImgFailed(true)}
         />
       ) : (
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/20 text-sm font-bold text-purple-300">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/20 text-sm font-bold text-primary">
           {stock.symbol.slice(0, 2)}
         </div>
       )}
-      <span className="text-sm font-bold text-white">{stock.symbol}</span>
-      <span className="max-w-[160px] truncate text-center text-[10px] text-gray-400">
+      <span className="text-sm font-bold text-foreground">{stock.symbol}</span>
+      <span className="max-w-[160px] truncate text-center text-[10px] text-muted-foreground">
         {stock.name}
       </span>
       <div className="flex items-center gap-1">
@@ -649,10 +649,10 @@ function StockHeader({
           {stock.changesPercentage.toFixed(2)}%
         </span>
       </div>
-      <div className="flex gap-2 text-[9px] text-gray-500">
+      <div className="flex gap-2 text-[9px] text-muted-foreground">
         <span>{stock.sector}</span>
       </div>
-      <span className="font-mono text-[10px] text-gray-400">
+      <span className="font-mono text-[10px] text-muted-foreground">
         MCap: {formatLargeNumber(stock.marketCap)}
       </span>
     </div>
@@ -731,9 +731,9 @@ function SuggestedPeers({
   if (allPeers.length === 0) return null;
 
   return (
-    <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+    <div className="rounded-xl border border-border bg-foreground/5 p-4">
       <div className="mb-3 flex items-center gap-2">
-        <Users className="h-4 w-4 text-purple-400" />
+        <Users className="h-4 w-4 text-primary" />
         <span className="text-sm font-semibold text-gray-200">
           Suggested Competitors
         </span>
@@ -743,7 +743,7 @@ function SuggestedPeers({
           <button
             key={peer}
             onClick={() => onAdd(peer)}
-            className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-gray-300 transition-all hover:border-purple-400/40 hover:bg-purple-500/10 hover:text-white"
+            className="flex items-center gap-1.5 rounded-lg border border-border bg-foreground/5 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-all hover:border-primary/40 hover:bg-primary/10 hover:text-foreground"
           >
             <Plus className="h-3 w-3" />
             {peer}
@@ -892,22 +892,22 @@ export function StockComparison() {
 
       {/* Comparison table */}
       {totalColumns > 0 && (
-        <div className="overflow-x-auto rounded-xl border border-white/10">
+        <div className="overflow-x-auto rounded-xl border border-border">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-white/10 bg-white/5">
-                <th className="sticky left-0 z-10 min-w-[200px] bg-[#1a1b35] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">
+              <tr className="border-b border-border bg-foreground/5">
+                <th className="sticky left-0 z-10 min-w-[200px] bg-[#1a1b35] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Metric
                 </th>
                 {symbols.map((s) => (
                   <th
                     key={s}
-                    className="min-w-[140px] px-3 py-3 text-center text-sm font-bold text-white"
+                    className="min-w-[140px] px-3 py-3 text-center text-sm font-bold text-foreground"
                   >
                     {s}
                   </th>
                 ))}
-                <th className="min-w-[180px] px-3 py-3 text-center text-xs font-semibold uppercase tracking-wider text-gray-500">
+                <th className="min-w-[180px] px-3 py-3 text-center text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Benchmark
                 </th>
               </tr>
@@ -919,7 +919,7 @@ export function StockComparison() {
                   <React.Fragment key={section.title}>
                     {/* Section header row */}
                     <tr
-                      className="cursor-pointer border-b border-white/5 bg-purple-500/5 transition-colors hover:bg-purple-500/10"
+                      className="cursor-pointer border-b border-border bg-primary/5 transition-colors hover:bg-primary/10"
                       onClick={() => toggleSection(section.title)}
                     >
                       <td
@@ -927,16 +927,16 @@ export function StockComparison() {
                         className="sticky left-0 z-10 px-4 py-2.5"
                       >
                         <div className="flex items-center gap-2">
-                          <span className="text-purple-400">
+                          <span className="text-primary">
                             {section.icon}
                           </span>
-                          <span className="text-sm font-semibold text-purple-300">
+                          <span className="text-sm font-semibold text-primary">
                             {section.title}
                           </span>
                           {isCollapsed ? (
-                            <ChevronDown className="h-4 w-4 text-gray-500" />
+                            <ChevronDown className="h-4 w-4 text-muted-foreground" />
                           ) : (
-                            <ChevronUp className="h-4 w-4 text-gray-500" />
+                            <ChevronUp className="h-4 w-4 text-muted-foreground" />
                           )}
                         </div>
                       </td>
@@ -979,9 +979,9 @@ export function StockComparison() {
                         return (
                           <tr
                             key={metric.key}
-                            className="border-b border-white/5 transition-colors hover:bg-white/2"
+                            className="border-b border-border transition-colors hover:bg-accent"
                           >
-                            <td className="sticky left-0 z-10 bg-background px-4 py-2 text-xs text-gray-300">
+                            <td className="sticky left-0 z-10 bg-background px-4 py-2 text-xs text-muted-foreground">
                               <div className="flex items-center gap-1">
                                 {metric.label}
                               </div>
@@ -1000,7 +1000,7 @@ export function StockComparison() {
                                 <MetricCellSkeleton key={s} />
                               ),
                             )}
-                            <td className="px-3 py-2 text-center text-[10px] text-gray-500">
+                            <td className="px-3 py-2 text-center text-[10px] text-muted-foreground">
                               {BENCHMARKS[metric.key] ?? ""}
                             </td>
                           </tr>
@@ -1012,7 +1012,7 @@ export function StockComparison() {
 
               {/* Market Data Section */}
               <tr
-                className="cursor-pointer border-b border-white/5 bg-purple-500/5 transition-colors hover:bg-purple-500/10"
+                className="cursor-pointer border-b border-border bg-primary/5 transition-colors hover:bg-primary/10"
                 onClick={() => toggleSection("__market")}
               >
                 <td
@@ -1020,14 +1020,14 @@ export function StockComparison() {
                   className="sticky left-0 z-10 px-4 py-2.5"
                 >
                   <div className="flex items-center gap-2">
-                    <BarChart3 className="h-4 w-4 text-purple-400" />
-                    <span className="text-sm font-semibold text-purple-300">
+                    <BarChart3 className="h-4 w-4 text-primary" />
+                    <span className="text-sm font-semibold text-primary">
                       Market Data
                     </span>
                     {collapsedSections.has("__market") ? (
-                      <ChevronDown className="h-4 w-4 text-gray-500" />
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
                     ) : (
-                      <ChevronUp className="h-4 w-4 text-gray-500" />
+                      <ChevronUp className="h-4 w-4 text-muted-foreground" />
                     )}
                   </div>
                 </td>
@@ -1043,7 +1043,7 @@ export function StockComparison() {
                       label: "52W Range",
                       render: (s: CompareStock) =>
                         `$${s.yearLow.toFixed(0)} – $${s.yearHigh.toFixed(0)}`,
-                      className: "font-mono text-xs text-gray-300",
+                      className: "font-mono text-xs text-muted-foreground",
                     },
                     {
                       label: "50-Day Avg",
@@ -1070,19 +1070,19 @@ export function StockComparison() {
                     {
                       label: "Sector",
                       render: (s: CompareStock) => s.sector || "N/A",
-                      className: "text-xs text-gray-300",
+                      className: "text-xs text-muted-foreground",
                     },
                     {
                       label: "Industry",
                       render: (s: CompareStock) => s.industry || "N/A",
-                      className: "text-xs text-gray-300",
+                      className: "text-xs text-muted-foreground",
                     },
                   ].map((row) => (
                     <tr
                       key={row.label}
-                      className="border-b border-white/5 transition-colors hover:bg-white/2"
+                      className="border-b border-border transition-colors hover:bg-accent"
                     >
-                      <td className="sticky left-0 z-10 bg-background px-4 py-2 text-xs text-gray-300">
+                      <td className="sticky left-0 z-10 bg-background px-4 py-2 text-xs text-muted-foreground">
                         {row.label}
                       </td>
                       {symbols.map((s, i) =>
@@ -1100,7 +1100,7 @@ export function StockComparison() {
                           <MetricCellSkeleton key={s} />
                         ),
                       )}
-                      <td className="px-3 py-2 text-center text-[10px] text-gray-500" />
+                      <td className="px-3 py-2 text-center text-[10px] text-muted-foreground" />
                     </tr>
                   ))}
                 </>
@@ -1114,10 +1114,10 @@ export function StockComparison() {
       {symbols.length === 0 && (
         <div className="flex flex-col items-center justify-center py-32 text-center">
           <BarChart3 className="mb-4 h-12 w-12 text-gray-600" />
-          <h2 className="mb-2 text-lg font-semibold text-gray-300">
+          <h2 className="mb-2 text-lg font-semibold text-muted-foreground">
             Compare Stocks Side by Side
           </h2>
-          <p className="mb-6 max-w-md text-sm text-gray-500">
+          <p className="mb-6 max-w-md text-sm text-muted-foreground">
             Add up to 6 stocks to compare their fundamentals, valuations, growth
             metrics, profitability, and more.
           </p>

--- a/src/components/features/stock-comparison.tsx
+++ b/src/components/features/stock-comparison.tsx
@@ -613,7 +613,7 @@ function StockHeader({
     <div className="group relative flex w-[180px] flex-col items-center gap-2 rounded-xl border border-border bg-foreground/5 px-3 py-4 transition-all hover:border-primary/30">
       <button
         onClick={onRemove}
-        className="absolute -right-2 -top-2 hidden rounded-full bg-red-500/90 p-1 text-foreground transition-all hover:bg-red-400 group-hover:block"
+        className="absolute -right-2 -top-2 hidden rounded-full bg-negative-surface p-1 text-foreground transition-all hover:bg-red-400 group-hover:block"
       >
         <X className="h-3 w-3" />
       </button>
@@ -642,7 +642,7 @@ function StockHeader({
         <span
           className={cn(
             "font-mono text-[10px]",
-            stock.changesPercentage >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400",
+            stock.changesPercentage >= 0 ? "text-positive" : "text-negative",
           )}
         >
           {stock.changesPercentage >= 0 ? "+" : ""}
@@ -678,10 +678,10 @@ function MetricCell({
   const isNeg = value != null && value < 0;
 
   let textColor = "text-muted-foreground";
-  if (better !== "neutral" && isBest) textColor = "text-green-700 dark:text-green-400";
-  if (better !== "neutral" && isWorst) textColor = "text-red-700 dark:text-red-400";
+  if (better !== "neutral" && isBest) textColor = "text-positive";
+  if (better !== "neutral" && isWorst) textColor = "text-negative";
   if (better === "neutral" && isGrowth) {
-    textColor = isNeg ? "text-red-700 dark:text-red-400" : "text-green-700 dark:text-green-400";
+    textColor = isNeg ? "text-negative" : "text-positive";
   }
 
   return (
@@ -689,17 +689,17 @@ function MetricCell({
       <div
         className={cn(
           "inline-flex items-center gap-1 rounded-md px-2 py-0.5 font-mono text-sm font-medium",
-          isBest && better !== "neutral" && "bg-green-500/10",
-          isWorst && better !== "neutral" && "bg-red-500/10",
+          isBest && better !== "neutral" && "bg-positive-surface",
+          isWorst && better !== "neutral" && "bg-negative-surface",
           textColor,
         )}
       >
         {formatted}
         {isBest && better !== "neutral" && (
-          <TrendingUp className="h-3 w-3 text-green-700 dark:text-green-400" />
+          <TrendingUp className="h-3 w-3 text-positive" />
         )}
         {isWorst && better !== "neutral" && (
-          <TrendingDown className="h-3 w-3 text-red-700 dark:text-red-400" />
+          <TrendingDown className="h-3 w-3 text-negative" />
         )}
       </div>
     </td>

--- a/src/components/features/stock-comparison.tsx
+++ b/src/components/features/stock-comparison.tsx
@@ -642,7 +642,7 @@ function StockHeader({
         <span
           className={cn(
             "font-mono text-[10px]",
-            stock.changesPercentage >= 0 ? "text-green-400" : "text-red-400",
+            stock.changesPercentage >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400",
           )}
         >
           {stock.changesPercentage >= 0 ? "+" : ""}
@@ -678,10 +678,10 @@ function MetricCell({
   const isNeg = value != null && value < 0;
 
   let textColor = "text-muted-foreground";
-  if (better !== "neutral" && isBest) textColor = "text-green-400";
-  if (better !== "neutral" && isWorst) textColor = "text-red-400";
+  if (better !== "neutral" && isBest) textColor = "text-green-700 dark:text-green-400";
+  if (better !== "neutral" && isWorst) textColor = "text-red-700 dark:text-red-400";
   if (better === "neutral" && isGrowth) {
-    textColor = isNeg ? "text-red-400" : "text-green-400";
+    textColor = isNeg ? "text-red-700 dark:text-red-400" : "text-green-700 dark:text-green-400";
   }
 
   return (
@@ -696,10 +696,10 @@ function MetricCell({
       >
         {formatted}
         {isBest && better !== "neutral" && (
-          <TrendingUp className="h-3 w-3 text-green-400" />
+          <TrendingUp className="h-3 w-3 text-green-700 dark:text-green-400" />
         )}
         {isWorst && better !== "neutral" && (
-          <TrendingDown className="h-3 w-3 text-red-400" />
+          <TrendingDown className="h-3 w-3 text-red-700 dark:text-red-400" />
         )}
       </div>
     </td>

--- a/src/components/features/stock-peers.tsx
+++ b/src/components/features/stock-peers.tsx
@@ -115,8 +115,8 @@ export const StockPeers = () => {
                   <span
                     className={`font-mono text-xs ${
                       peer.changesPercentage >= 0
-                        ? "text-green-400"
-                        : "text-red-400"
+                        ? "text-green-700 dark:text-green-400"
+                        : "text-red-700 dark:text-red-400"
                     }`}
                   >
                     {peer.changesPercentage >= 0 ? "+" : ""}

--- a/src/components/features/stock-peers.tsx
+++ b/src/components/features/stock-peers.tsx
@@ -37,8 +37,8 @@ export const StockPeers = () => {
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <Users className="h-4 w-4 text-primary" />
-          <span className="text-sm font-semibold text-gray-200">
+          <Users className="h-4 w-4 text-foreground" />
+          <span className="text-sm font-semibold text-muted-foreground">
             Competitors
           </span>
         </div>
@@ -59,8 +59,8 @@ export const StockPeers = () => {
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <Users className="h-4 w-4 text-primary" />
-          <span className="text-sm font-semibold text-gray-200">
+          <Users className="h-4 w-4 text-foreground" />
+          <span className="text-sm font-semibold text-muted-foreground">
             Competitors
           </span>
         </div>
@@ -74,8 +74,8 @@ export const StockPeers = () => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-        <Users className="h-4 w-4 text-primary" />
-        <span className="text-sm font-semibold text-gray-200">Competitors</span>
+        <Users className="h-4 w-4 text-foreground" />
+        <span className="text-sm font-semibold text-muted-foreground">Competitors</span>
       </div>
       <div className="flex-1 overflow-auto">
         <table className="w-full text-sm">
@@ -99,7 +99,7 @@ export const StockPeers = () => {
                   <div className="flex items-center gap-2">
                     <PeerLogo symbol={peer.symbol} />
                     <div className="min-w-0">
-                      <div className="font-mono text-xs font-semibold text-primary">
+                      <div className="font-mono text-xs font-semibold text-foreground">
                         {peer.symbol}
                       </div>
                       <div className="truncate text-[10px] text-muted-foreground">
@@ -108,7 +108,7 @@ export const StockPeers = () => {
                     </div>
                   </div>
                 </td>
-                <td className="px-3 py-1.5 text-right font-mono text-xs text-gray-200">
+                <td className="px-3 py-1.5 text-right font-mono text-xs text-muted-foreground">
                   ${peer.price?.toFixed(2)}
                 </td>
                 <td className="px-3 py-1.5 text-right">

--- a/src/components/features/stock-peers.tsx
+++ b/src/components/features/stock-peers.tsx
@@ -10,7 +10,7 @@ import { Users } from "lucide-react";
 function PeerLogo({ symbol }: { symbol: string }) {
   const [failed, setFailed] = useState(false);
   return failed ? (
-    <div className="flex h-8 w-8 items-center justify-center rounded bg-white/10 text-[10px] font-bold text-gray-300">
+    <div className="flex h-8 w-8 items-center justify-center rounded bg-foreground/10 text-[10px] font-bold text-muted-foreground">
       {symbol.slice(0, 2)}
     </div>
   ) : (
@@ -36,8 +36,8 @@ export const StockPeers = () => {
   if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
-          <Users className="h-4 w-4 text-purple-400" />
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+          <Users className="h-4 w-4 text-primary" />
           <span className="text-sm font-semibold text-gray-200">
             Competitors
           </span>
@@ -45,9 +45,9 @@ export const StockPeers = () => {
         <div className="flex-1 space-y-2 p-4">
           {[1, 2, 3, 4, 5].map((i) => (
             <div key={i} className="flex animate-pulse items-center gap-3">
-              <div className="h-8 w-8 rounded bg-white/10" />
-              <div className="h-4 w-16 rounded bg-white/10" />
-              <div className="ml-auto h-4 w-12 rounded bg-white/10" />
+              <div className="h-8 w-8 rounded bg-foreground/10" />
+              <div className="h-4 w-16 rounded bg-foreground/10" />
+              <div className="ml-auto h-4 w-12 rounded bg-foreground/10" />
             </div>
           ))}
         </div>
@@ -58,13 +58,13 @@ export const StockPeers = () => {
   if (!data?.length) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
-          <Users className="h-4 w-4 text-purple-400" />
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+          <Users className="h-4 w-4 text-primary" />
           <span className="text-sm font-semibold text-gray-200">
             Competitors
           </span>
         </div>
-        <div className="flex flex-1 items-center justify-center text-sm text-gray-500">
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No peer data available
         </div>
       </div>
@@ -73,14 +73,14 @@ export const StockPeers = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-2 border-b border-white/10 px-4 py-2">
-        <Users className="h-4 w-4 text-purple-400" />
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+        <Users className="h-4 w-4 text-primary" />
         <span className="text-sm font-semibold text-gray-200">Competitors</span>
       </div>
       <div className="flex-1 overflow-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-white/5 text-[11px] uppercase text-gray-500">
+            <tr className="border-b border-border text-[11px] uppercase text-muted-foreground">
               <th className="px-3 py-1.5 text-left">Company</th>
               <th className="px-3 py-1.5 text-right">Price</th>
               <th className="px-3 py-1.5 text-right">Change</th>
@@ -93,16 +93,16 @@ export const StockPeers = () => {
             {data.map((peer) => (
               <tr
                 key={peer.symbol}
-                className="border-b border-white/5 transition-colors hover:bg-white/5"
+                className="border-b border-border transition-colors hover:bg-accent"
               >
                 <td className="px-3 py-1.5">
                   <div className="flex items-center gap-2">
                     <PeerLogo symbol={peer.symbol} />
                     <div className="min-w-0">
-                      <div className="font-mono text-xs font-semibold text-purple-300">
+                      <div className="font-mono text-xs font-semibold text-primary">
                         {peer.symbol}
                       </div>
-                      <div className="truncate text-[10px] text-gray-500">
+                      <div className="truncate text-[10px] text-muted-foreground">
                         {peer.name}
                       </div>
                     </div>
@@ -123,7 +123,7 @@ export const StockPeers = () => {
                     {peer.changesPercentage?.toFixed(2)}%
                   </span>
                 </td>
-                <td className="hidden px-3 py-1.5 text-right font-mono text-xs text-gray-400 sm:table-cell">
+                <td className="hidden px-3 py-1.5 text-right font-mono text-xs text-muted-foreground sm:table-cell">
                   {formatLargeNumber(peer.marketCap)}
                 </td>
               </tr>

--- a/src/components/features/stock-peers.tsx
+++ b/src/components/features/stock-peers.tsx
@@ -115,8 +115,8 @@ export const StockPeers = () => {
                   <span
                     className={`font-mono text-xs ${
                       peer.changesPercentage >= 0
-                        ? "text-green-700 dark:text-green-400"
-                        : "text-red-700 dark:text-red-400"
+                        ? "text-positive"
+                        : "text-negative"
                     }`}
                   >
                     {peer.changesPercentage >= 0 ? "+" : ""}

--- a/src/components/features/stock-response-modal.tsx
+++ b/src/components/features/stock-response-modal.tsx
@@ -24,7 +24,7 @@ interface StockResponseModalProps {
 
 const MarkdownWithColor = ({ content }: { content: string }) => {
   return (
-    <div className="prose prose-invert max-w-none text-sm">
+    <div className="prose dark:prose-invert max-w-none text-sm">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -99,13 +99,13 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
             }
             if (className) {
               return (
-                <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-gray-200">
+                <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-muted-foreground">
                   <code>{children}</code>
                 </pre>
               );
             }
             return (
-              <code className="rounded bg-foreground/10 px-1 py-0.5 text-sm text-gray-200">
+              <code className="rounded bg-foreground/10 px-1 py-0.5 text-sm text-muted-foreground">
                 {children}
               </code>
             );

--- a/src/components/features/stock-response-modal.tsx
+++ b/src/components/features/stock-response-modal.tsx
@@ -29,7 +29,7 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
         remarkPlugins={[remarkGfm]}
         components={{
           p: ({ children }) => {
-            return <p className="mt-2 text-white">{children}</p>;
+            return <p className="mt-2 text-foreground">{children}</p>;
           },
           strong: ({ children }) => {
             const text = typeof children === "string" ? children : null;
@@ -62,32 +62,32 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
           },
           h1: ({ children }) => {
             return (
-              <h1 className="text-2xl font-bold text-white">{children}</h1>
+              <h1 className="text-2xl font-bold text-foreground">{children}</h1>
             );
           },
           h2: ({ children }) => {
             return (
-              <h2 className="mb-2 mt-4 text-xl font-bold text-white">
+              <h2 className="mb-2 mt-4 text-xl font-bold text-foreground">
                 {children}
               </h2>
             );
           },
           h3: ({ children }) => {
             return (
-              <h3 className="mb-2 mt-3 text-lg font-bold text-white">
+              <h3 className="mb-2 mt-3 text-lg font-bold text-foreground">
                 {children}
               </h3>
             );
           },
           ul: ({ children }) => {
             return (
-              <ul className="list-inside list-disc space-y-1 text-white">
+              <ul className="list-inside list-disc space-y-1 text-foreground">
                 {children}
               </ul>
             );
           },
           li: ({ children }) => {
-            return <li className="text-white">{children}</li>;
+            return <li className="text-foreground">{children}</li>;
           },
           pre: ({ children }) => {
             return <>{children}</>;
@@ -99,13 +99,13 @@ const MarkdownWithColor = ({ content }: { content: string }) => {
             }
             if (className) {
               return (
-                <pre className="overflow-x-auto rounded-md bg-white/10 p-3 text-sm text-gray-200">
+                <pre className="overflow-x-auto rounded-md bg-foreground/10 p-3 text-sm text-gray-200">
                   <code>{children}</code>
                 </pre>
               );
             }
             return (
-              <code className="rounded bg-white/10 px-1 py-0.5 text-sm text-gray-200">
+              <code className="rounded bg-foreground/10 px-1 py-0.5 text-sm text-gray-200">
                 {children}
               </code>
             );
@@ -127,19 +127,19 @@ export function StockResponseModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="flex h-[80vh] max-w-5xl flex-col border-white/20 bg-background text-white">
+      <DialogContent className="flex h-[80vh] max-w-5xl flex-col border-border bg-background text-foreground">
         <DialogHeader>
-          <DialogTitle className="text-xl font-bold text-white">
+          <DialogTitle className="text-xl font-bold text-foreground">
             {stock.supabaseId} - Analysis Report
           </DialogTitle>
         </DialogHeader>
         <div className="min-h-0 flex-1">
           <ScrollArea className="h-full w-full">
-            <div className="rounded-md border border-white/10 bg-white/5 p-4">
+            <div className="rounded-md border border-border bg-foreground/5 p-4">
               {stock.response ? (
                 <MarkdownWithColor content={stock.response} />
               ) : (
-                <p className="text-gray-400">No analysis available</p>
+                <p className="text-muted-foreground">No analysis available</p>
               )}
             </div>
           </ScrollArea>

--- a/src/components/features/stock-response-modal.tsx
+++ b/src/components/features/stock-response-modal.tsx
@@ -127,7 +127,7 @@ export function StockResponseModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="flex h-[80vh] max-w-5xl flex-col border-white/20 bg-[#15162c] text-white">
+      <DialogContent className="flex h-[80vh] max-w-5xl flex-col border-white/20 bg-background text-white">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-white">
             {stock.supabaseId} - Analysis Report

--- a/src/components/features/super-investor-consensus.tsx
+++ b/src/components/features/super-investor-consensus.tsx
@@ -62,7 +62,7 @@ function SymbolRow({ row, rank }: { row: Row; rank: number }) {
   const sellerNames = row.sellerNames ?? [];
 
   return (
-    <div className="flex items-center gap-3 rounded-md bg-black/20 px-3 py-2">
+    <div className="flex items-center gap-3 rounded-md bg-muted px-3 py-2">
       <span className="w-4 shrink-0 text-right text-xs text-muted-foreground">{rank}</span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -77,8 +77,8 @@ function SymbolRow({ row, rank }: { row: Row; rank: number }) {
         {row.name && <p className="truncate text-xs text-muted-foreground">{row.name}</p>}
       </div>
       <div className="shrink-0 text-right text-sm">
-        <InvestorCount count={buyers} arrow="↑" color="text-emerald-400" names={buyerNames} />{" "}
-        <InvestorCount count={sellers} arrow="↓" color="text-rose-400" names={sellerNames} />
+        <InvestorCount count={buyers} arrow="↑" color="text-emerald-700 dark:text-emerald-400" names={buyerNames} />{" "}
+        <InvestorCount count={sellers} arrow="↓" color="text-rose-700 dark:text-rose-400" names={sellerNames} />
       </div>
     </div>
   );
@@ -122,14 +122,14 @@ export function InvestorConsensus({ consensus }: { consensus: Consensus }) {
         <Side
           title="Most bought"
           icon={<ShoppingCart className="h-4 w-4" />}
-          accent="text-emerald-400"
+          accent="text-emerald-700 dark:text-emerald-400"
           rows={consensus.bought}
           empty="No multi-investor buying this quarter."
         />
         <Side
           title="Most sold"
           icon={<TrendingDown className="h-4 w-4" />}
-          accent="text-rose-400"
+          accent="text-rose-700 dark:text-rose-400"
           rows={consensus.sold}
           empty="No multi-investor selling this quarter."
         />

--- a/src/components/features/super-investor-consensus.tsx
+++ b/src/components/features/super-investor-consensus.tsx
@@ -77,8 +77,8 @@ function SymbolRow({ row, rank }: { row: Row; rank: number }) {
         {row.name && <p className="truncate text-xs text-muted-foreground">{row.name}</p>}
       </div>
       <div className="shrink-0 text-right text-sm">
-        <InvestorCount count={buyers} arrow="↑" color="text-emerald-700 dark:text-emerald-400" names={buyerNames} />{" "}
-        <InvestorCount count={sellers} arrow="↓" color="text-rose-700 dark:text-rose-400" names={sellerNames} />
+        <InvestorCount count={buyers} arrow="↑" color="text-positive" names={buyerNames} />{" "}
+        <InvestorCount count={sellers} arrow="↓" color="text-negative" names={sellerNames} />
       </div>
     </div>
   );
@@ -122,14 +122,14 @@ export function InvestorConsensus({ consensus }: { consensus: Consensus }) {
         <Side
           title="Most bought"
           icon={<ShoppingCart className="h-4 w-4" />}
-          accent="text-emerald-700 dark:text-emerald-400"
+          accent="text-positive"
           rows={consensus.bought}
           empty="No multi-investor buying this quarter."
         />
         <Side
           title="Most sold"
           icon={<TrendingDown className="h-4 w-4" />}
-          accent="text-rose-700 dark:text-rose-400"
+          accent="text-negative"
           rows={consensus.sold}
           empty="No multi-investor selling this quarter."
         />

--- a/src/components/features/super-investor-consensus.tsx
+++ b/src/components/features/super-investor-consensus.tsx
@@ -63,18 +63,18 @@ function SymbolRow({ row, rank }: { row: Row; rank: number }) {
 
   return (
     <div className="flex items-center gap-3 rounded-md bg-black/20 px-3 py-2">
-      <span className="w-4 shrink-0 text-right text-xs text-gray-500">{rank}</span>
+      <span className="w-4 shrink-0 text-right text-xs text-muted-foreground">{rank}</span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <Link
             href={`/?symbol=${row.ticker}`}
-            className="font-semibold text-white hover:underline"
+            className="font-semibold text-foreground hover:underline"
           >
             {row.ticker}
           </Link>
           <InvestorConsensusBadge consensus={consensus} />
         </div>
-        {row.name && <p className="truncate text-xs text-gray-500">{row.name}</p>}
+        {row.name && <p className="truncate text-xs text-muted-foreground">{row.name}</p>}
       </div>
       <div className="shrink-0 text-right text-sm">
         <InvestorCount count={buyers} arrow="↑" color="text-emerald-400" names={buyerNames} />{" "}
@@ -98,7 +98,7 @@ function Side({
   empty: string;
 }) {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="space-y-0 pb-3">
         <div className={`flex items-center gap-2 text-sm font-semibold ${accent}`}>
           {icon} {title}
@@ -106,7 +106,7 @@ function Side({
       </CardHeader>
       <CardContent className="space-y-1.5">
         {(rows?.length ?? 0) === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-500">{empty}</p>
+          <p className="py-6 text-center text-sm text-muted-foreground">{empty}</p>
         ) : (
           rows?.map((row, i) => <SymbolRow key={row.ticker} row={row} rank={i + 1} />)
         )}

--- a/src/components/features/super-investor-moves.tsx
+++ b/src/components/features/super-investor-moves.tsx
@@ -16,7 +16,7 @@ function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
       <div className="min-w-0">
         <Link
           href={`/investors/${m.slug}`}
-          className="text-xs text-primary hover:underline"
+          className="text-xs text-foreground hover:underline"
         >
           {m.investor}
         </Link>

--- a/src/components/features/super-investor-moves.tsx
+++ b/src/components/features/super-investor-moves.tsx
@@ -12,7 +12,7 @@ type Move = Moves["newBuys"][number];
 
 function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-md bg-black/20 px-3 py-2 text-sm">
+    <div className="flex items-center justify-between gap-3 rounded-md bg-muted px-3 py-2 text-sm">
       <div className="min-w-0">
         <Link
           href={`/investors/${m.slug}`}
@@ -35,7 +35,7 @@ function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
         </div>
       </div>
       <div className="shrink-0 text-right">
-        <div className={kind === "buy" ? "text-emerald-400" : "text-rose-400"}>
+        <div className={kind === "buy" ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"}>
           {formatMoney(m.value)}
         </div>
         {kind === "buy" && m.pctPortfolio > 0 && (
@@ -98,7 +98,7 @@ export function InvestorMoves({ moves }: { moves: Moves }) {
       <MoveCard
         title="Biggest new buys"
         icon={<Sparkles className="h-4 w-4" />}
-        accent="text-emerald-400"
+        accent="text-emerald-700 dark:text-emerald-400"
         rows={moves.newBuys}
         empty="No new positions this quarter."
         kind="buy"
@@ -106,7 +106,7 @@ export function InvestorMoves({ moves }: { moves: Moves }) {
       <MoveCard
         title="Full exits"
         icon={<DoorOpen className="h-4 w-4" />}
-        accent="text-rose-400"
+        accent="text-rose-700 dark:text-rose-400"
         rows={moves.exits}
         empty="No full exits this quarter."
         kind="sell"

--- a/src/components/features/super-investor-moves.tsx
+++ b/src/components/features/super-investor-moves.tsx
@@ -35,7 +35,7 @@ function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
         </div>
       </div>
       <div className="shrink-0 text-right">
-        <div className={kind === "buy" ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"}>
+        <div className={kind === "buy" ? "text-positive" : "text-negative"}>
           {formatMoney(m.value)}
         </div>
         {kind === "buy" && m.pctPortfolio > 0 && (
@@ -98,7 +98,7 @@ export function InvestorMoves({ moves }: { moves: Moves }) {
       <MoveCard
         title="Biggest new buys"
         icon={<Sparkles className="h-4 w-4" />}
-        accent="text-emerald-700 dark:text-emerald-400"
+        accent="text-positive"
         rows={moves.newBuys}
         empty="No new positions this quarter."
         kind="buy"
@@ -106,7 +106,7 @@ export function InvestorMoves({ moves }: { moves: Moves }) {
       <MoveCard
         title="Full exits"
         icon={<DoorOpen className="h-4 w-4" />}
-        accent="text-rose-700 dark:text-rose-400"
+        accent="text-negative"
         rows={moves.exits}
         empty="No full exits this quarter."
         kind="sell"

--- a/src/components/features/super-investor-moves.tsx
+++ b/src/components/features/super-investor-moves.tsx
@@ -16,7 +16,7 @@ function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
       <div className="min-w-0">
         <Link
           href={`/investors/${m.slug}`}
-          className="text-xs text-purple-200 hover:underline"
+          className="text-xs text-primary hover:underline"
         >
           {m.investor}
         </Link>
@@ -24,14 +24,14 @@ function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
           {m.ticker ? (
             <Link
               href={`/?symbol=${m.ticker}`}
-              className="font-semibold text-white hover:underline"
+              className="font-semibold text-foreground hover:underline"
             >
               {m.ticker}
             </Link>
           ) : (
-            <span className="font-medium text-gray-400">—</span>
+            <span className="font-medium text-muted-foreground">—</span>
           )}
-          <span className="truncate text-xs text-gray-500">{m.name}</span>
+          <span className="truncate text-xs text-muted-foreground">{m.name}</span>
         </div>
       </div>
       <div className="shrink-0 text-right">
@@ -39,12 +39,12 @@ function MoveRow({ m, kind }: { m: Move; kind: "buy" | "sell" }) {
           {formatMoney(m.value)}
         </div>
         {kind === "buy" && m.pctPortfolio > 0 && (
-          <div className="text-[11px] text-gray-500">
+          <div className="text-[11px] text-muted-foreground">
             {Math.round(m.pctPortfolio)}% of book
           </div>
         )}
         {kind === "sell" && (
-          <div className="text-[11px] text-gray-500">exited</div>
+          <div className="text-[11px] text-muted-foreground">exited</div>
         )}
       </div>
     </div>
@@ -67,7 +67,7 @@ function MoveCard({
   kind: "buy" | "sell";
 }) {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="space-y-0 pb-3">
         <div
           className={`flex items-center gap-2 text-sm font-semibold ${accent}`}
@@ -77,7 +77,7 @@ function MoveCard({
       </CardHeader>
       <CardContent className="space-y-1.5">
         {(rows?.length ?? 0) === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-500">{empty}</p>
+          <p className="py-6 text-center text-sm text-muted-foreground">{empty}</p>
         ) : (
           (rows ?? []).map((m, i) => (
             <MoveRow

--- a/src/components/features/super-investor-roster.tsx
+++ b/src/components/features/super-investor-roster.tsx
@@ -24,7 +24,7 @@ function InvestorCard({ inv }: { inv: Investor }) {
   return (
     <Link
       href={`/investors/${inv.slug}`}
-      className="group block rounded-lg border border-border bg-black/20 p-3 transition-colors hover:bg-accent"
+      className="group block rounded-lg border border-border bg-muted p-3 transition-colors hover:bg-accent"
     >
       <div className="flex items-center gap-3">
         <Avatar className="h-10 w-10 shrink-0">
@@ -45,10 +45,10 @@ function InvestorCard({ inv }: { inv: Investor }) {
         )}
       </div>
       <div className="mt-2 flex flex-wrap gap-x-2 gap-y-0.5 text-[11px]">
-        {moves.new > 0 && <span className="text-emerald-400">{moves.new} new</span>}
-        {moves.added > 0 && <span className="text-emerald-300">{moves.added} added</span>}
-        {moves.reduced > 0 && <span className="text-amber-300">{moves.reduced} trimmed</span>}
-        {moves.sold > 0 && <span className="text-rose-400">{moves.sold} exited</span>}
+        {moves.new > 0 && <span className="text-emerald-700 dark:text-emerald-400">{moves.new} new</span>}
+        {moves.added > 0 && <span className="text-emerald-700 dark:text-emerald-400">{moves.added} added</span>}
+        {moves.reduced > 0 && <span className="text-amber-700 dark:text-amber-400">{moves.reduced} trimmed</span>}
+        {moves.sold > 0 && <span className="text-rose-700 dark:text-rose-400">{moves.sold} exited</span>}
         {inv.period === null && <span className="text-gray-600">no filing yet</span>}
       </div>
     </Link>

--- a/src/components/features/super-investor-roster.tsx
+++ b/src/components/features/super-investor-roster.tsx
@@ -29,7 +29,7 @@ function InvestorCard({ inv }: { inv: Investor }) {
       <div className="flex items-center gap-3">
         <Avatar className="h-10 w-10 shrink-0">
           {inv.avatar && <AvatarImage src={inv.avatar} alt={inv.name} />}
-          <AvatarFallback className="bg-primary/20 text-xs text-primary">
+          <AvatarFallback className="bg-primary/20 text-xs text-foreground">
             {initials(inv.name)}
           </AvatarFallback>
         </Avatar>

--- a/src/components/features/super-investor-roster.tsx
+++ b/src/components/features/super-investor-roster.tsx
@@ -24,21 +24,21 @@ function InvestorCard({ inv }: { inv: Investor }) {
   return (
     <Link
       href={`/investors/${inv.slug}`}
-      className="group block rounded-lg border border-white/10 bg-black/20 p-3 transition-colors hover:bg-white/5"
+      className="group block rounded-lg border border-border bg-black/20 p-3 transition-colors hover:bg-accent"
     >
       <div className="flex items-center gap-3">
         <Avatar className="h-10 w-10 shrink-0">
           {inv.avatar && <AvatarImage src={inv.avatar} alt={inv.name} />}
-          <AvatarFallback className="bg-purple-500/20 text-xs text-purple-200">
+          <AvatarFallback className="bg-primary/20 text-xs text-primary">
             {initials(inv.name)}
           </AvatarFallback>
         </Avatar>
         <div className="min-w-0 flex-1">
-          <div className="truncate font-medium text-white group-hover:underline">{inv.name}</div>
-          <div className="truncate text-xs text-gray-500">{inv.firm}</div>
+          <div className="truncate font-medium text-foreground group-hover:underline">{inv.name}</div>
+          <div className="truncate text-xs text-muted-foreground">{inv.firm}</div>
         </div>
         {inv.totalValue != null && (
-          <div className="shrink-0 text-right text-xs text-gray-400">
+          <div className="shrink-0 text-right text-xs text-muted-foreground">
             {formatMoney(inv.totalValue)}
             <div className="text-gray-600">{inv.holdingsCount} pos</div>
           </div>
@@ -57,7 +57,7 @@ function InvestorCard({ inv }: { inv: Investor }) {
 
 export function InvestorRoster({ investors }: { investors: Investor[] }) {
   return (
-    <Card className="border-white/10 bg-white/5 text-white">
+    <Card className="border-border bg-foreground/5 text-foreground">
       <CardHeader className="pb-3">
         <h3 className="text-sm font-semibold">Tracked investors ({(investors?.length ?? 0)})</h3>
       </CardHeader>

--- a/src/components/features/super-investor-roster.tsx
+++ b/src/components/features/super-investor-roster.tsx
@@ -45,10 +45,10 @@ function InvestorCard({ inv }: { inv: Investor }) {
         )}
       </div>
       <div className="mt-2 flex flex-wrap gap-x-2 gap-y-0.5 text-[11px]">
-        {moves.new > 0 && <span className="text-emerald-700 dark:text-emerald-400">{moves.new} new</span>}
-        {moves.added > 0 && <span className="text-emerald-700 dark:text-emerald-400">{moves.added} added</span>}
-        {moves.reduced > 0 && <span className="text-amber-700 dark:text-amber-400">{moves.reduced} trimmed</span>}
-        {moves.sold > 0 && <span className="text-rose-700 dark:text-rose-400">{moves.sold} exited</span>}
+        {moves.new > 0 && <span className="text-positive">{moves.new} new</span>}
+        {moves.added > 0 && <span className="text-positive">{moves.added} added</span>}
+        {moves.reduced > 0 && <span className="text-warning">{moves.reduced} trimmed</span>}
+        {moves.sold > 0 && <span className="text-negative">{moves.sold} exited</span>}
         {inv.period === null && <span className="text-gray-600">no filing yet</span>}
       </div>
     </Link>

--- a/src/components/features/super-investor-section.tsx
+++ b/src/components/features/super-investor-section.tsx
@@ -24,19 +24,19 @@ export function SuperInvestorsSection() {
   const hasData = (investorsQ.data?.length ?? 0) > 0;
 
   return (
-    <section className="mt-12 border-t border-white/10 pt-8">
+    <section className="mt-12 border-t border-border pt-8">
       <div className="mb-1 flex items-center gap-2">
         <Landmark className="h-6 w-6 text-amber-400" />
         <h2 className="text-2xl font-bold">Super Investors</h2>
         {period && (
-          <span className="rounded-md bg-white/5 px-2 py-0.5 text-xs text-gray-400">
+          <span className="rounded-md bg-foreground/5 px-2 py-0.5 text-xs text-muted-foreground">
             13F · {periodLabel(period)}
           </span>
         )}
       </div>
-      <p className="mb-4 max-w-3xl text-sm text-gray-400">
+      <p className="mb-4 max-w-3xl text-sm text-muted-foreground">
         How legendary fund managers moved their books, from quarterly SEC 13F filings.{" "}
-        <span className="text-gray-500">
+        <span className="text-muted-foreground">
           13F covers long US positions only and lags ~45 days, so a sale means trimmed or
           exited — not short.
         </span>
@@ -44,12 +44,12 @@ export function SuperInvestorsSection() {
 
       {loading ? (
         <div className="space-y-4">
-          <Skeleton className="h-56 w-full rounded-xl bg-white/5" />
-          <Skeleton className="h-56 w-full rounded-xl bg-white/5" />
+          <Skeleton className="h-56 w-full rounded-xl bg-foreground/5" />
+          <Skeleton className="h-56 w-full rounded-xl bg-foreground/5" />
         </div>
       ) : !hasData ? (
-        <Card className="border-white/10 bg-white/5 text-white">
-          <CardContent className="py-12 text-center text-sm text-gray-400">
+        <Card className="border-border bg-foreground/5 text-foreground">
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
             No 13F data yet — run the superinvestor-job.
           </CardContent>
         </Card>

--- a/src/components/features/super-investor-section.tsx
+++ b/src/components/features/super-investor-section.tsx
@@ -26,7 +26,7 @@ export function SuperInvestorsSection() {
   return (
     <section className="mt-12 border-t border-border pt-8">
       <div className="mb-1 flex items-center gap-2">
-        <Landmark className="h-6 w-6 text-amber-400" />
+        <Landmark className="h-6 w-6 text-amber-700 dark:text-amber-400" />
         <h2 className="text-2xl font-bold">Super Investors</h2>
         {period && (
           <span className="rounded-md bg-foreground/5 px-2 py-0.5 text-xs text-muted-foreground">

--- a/src/components/features/super-investor-section.tsx
+++ b/src/components/features/super-investor-section.tsx
@@ -26,7 +26,7 @@ export function SuperInvestorsSection() {
   return (
     <section className="mt-12 border-t border-border pt-8">
       <div className="mb-1 flex items-center gap-2">
-        <Landmark className="h-6 w-6 text-amber-700 dark:text-amber-400" />
+        <Landmark className="h-6 w-6 text-warning" />
         <h2 className="text-2xl font-bold">Super Investors</h2>
         {period && (
           <span className="rounded-md bg-foreground/5 px-2 py-0.5 text-xs text-muted-foreground">

--- a/src/components/features/super-investor-shared.tsx
+++ b/src/components/features/super-investor-shared.tsx
@@ -2,9 +2,9 @@ import { Pill } from "./influencer-shared";
 
 const CONSENSUS: Record<string, string> = {
   strong_buy: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
-  buy: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/25",
-  mixed: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
-  sell: "bg-rose-500/10 text-rose-300 ring-rose-500/25",
+  buy: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
+  mixed: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30",
+  sell: "bg-rose-500/10 text-rose-700 dark:text-rose-400 ring-rose-500/25",
   strong_sell: "bg-rose-500/20 text-rose-200 ring-rose-500/40",
 };
 
@@ -26,9 +26,9 @@ const MOVE_LABEL: Record<string, string> = {
 };
 const MOVE_STYLE: Record<string, string> = {
   new: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
-  added: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/25",
-  reduced: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
-  sold: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
+  added: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
+  reduced: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30",
+  sold: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
   hold: "bg-slate-500/15 text-muted-foreground ring-slate-500/30",
 };
 
@@ -37,8 +37,8 @@ export function MoveBadge({ type }: { type: string }) {
 }
 
 export function moveColor(type: string): string {
-  if (type === "new" || type === "added") return "text-emerald-400";
-  if (type === "reduced" || type === "sold") return "text-rose-400";
+  if (type === "new" || type === "added") return "text-emerald-700 dark:text-emerald-400";
+  if (type === "reduced" || type === "sold") return "text-rose-700 dark:text-rose-400";
   return "text-slate-400";
 }
 

--- a/src/components/features/super-investor-shared.tsx
+++ b/src/components/features/super-investor-shared.tsx
@@ -1,11 +1,11 @@
 import { Pill } from "./influencer-shared";
 
 const CONSENSUS: Record<string, string> = {
-  strong_buy: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
+  strong_buy: "bg-emerald-500/20 text-emerald-800 dark:text-emerald-200 ring-emerald-500/40",
   buy: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
   mixed: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30",
   sell: "bg-rose-500/10 text-rose-700 dark:text-rose-400 ring-rose-500/25",
-  strong_sell: "bg-rose-500/20 text-rose-200 ring-rose-500/40",
+  strong_sell: "bg-rose-500/20 text-rose-800 dark:text-rose-200 ring-rose-500/40",
 };
 
 export function InvestorConsensusBadge({ consensus }: { consensus?: string }) {
@@ -25,7 +25,7 @@ const MOVE_LABEL: Record<string, string> = {
   hold: "hold",
 };
 const MOVE_STYLE: Record<string, string> = {
-  new: "bg-emerald-500/20 text-emerald-200 ring-emerald-500/40",
+  new: "bg-emerald-500/20 text-emerald-800 dark:text-emerald-200 ring-emerald-500/40",
   added: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
   reduced: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30",
   sold: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",

--- a/src/components/features/super-investor-shared.tsx
+++ b/src/components/features/super-investor-shared.tsx
@@ -29,7 +29,7 @@ const MOVE_STYLE: Record<string, string> = {
   added: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/25",
   reduced: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
   sold: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
-  hold: "bg-slate-500/15 text-slate-300 ring-slate-500/30",
+  hold: "bg-slate-500/15 text-muted-foreground ring-slate-500/30",
 };
 
 export function MoveBadge({ type }: { type: string }) {

--- a/src/components/features/super-investor-shared.tsx
+++ b/src/components/features/super-investor-shared.tsx
@@ -1,11 +1,11 @@
 import { Pill } from "./influencer-shared";
 
 const CONSENSUS: Record<string, string> = {
-  strong_buy: "bg-emerald-500/20 text-emerald-800 dark:text-emerald-200 ring-emerald-500/40",
-  buy: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
-  mixed: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30",
-  sell: "bg-rose-500/10 text-rose-700 dark:text-rose-400 ring-rose-500/25",
-  strong_sell: "bg-rose-500/20 text-rose-800 dark:text-rose-200 ring-rose-500/40",
+  strong_buy: "bg-positive-surface text-positive ring-positive/30",
+  buy: "bg-positive-surface text-positive ring-positive/30",
+  mixed: "bg-warning-surface text-warning ring-warning/30",
+  sell: "bg-negative-surface text-negative ring-negative/30",
+  strong_sell: "bg-negative-surface text-negative ring-negative/30",
 };
 
 export function InvestorConsensusBadge({ consensus }: { consensus?: string }) {
@@ -25,10 +25,10 @@ const MOVE_LABEL: Record<string, string> = {
   hold: "hold",
 };
 const MOVE_STYLE: Record<string, string> = {
-  new: "bg-emerald-500/20 text-emerald-800 dark:text-emerald-200 ring-emerald-500/40",
-  added: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
-  reduced: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/30",
-  sold: "bg-rose-500/15 text-rose-700 dark:text-rose-400 ring-rose-500/30",
+  new: "bg-positive-surface text-positive ring-positive/30",
+  added: "bg-positive-surface text-positive ring-positive/30",
+  reduced: "bg-warning-surface text-warning ring-warning/30",
+  sold: "bg-negative-surface text-negative ring-negative/30",
   hold: "bg-slate-500/15 text-muted-foreground ring-slate-500/30",
 };
 
@@ -37,8 +37,8 @@ export function MoveBadge({ type }: { type: string }) {
 }
 
 export function moveColor(type: string): string {
-  if (type === "new" || type === "added") return "text-emerald-700 dark:text-emerald-400";
-  if (type === "reduced" || type === "sold") return "text-rose-700 dark:text-rose-400";
+  if (type === "new" || type === "added") return "text-positive";
+  if (type === "reduced" || type === "sold") return "text-negative";
   return "text-slate-400";
 }
 

--- a/src/components/features/table-skeleton.tsx
+++ b/src/components/features/table-skeleton.tsx
@@ -16,43 +16,43 @@ interface TableSkeletonProps {
 
 export function TableSkeleton({ rows = 10 }: TableSkeletonProps) {
   return (
-    <div className="rounded-lg border border-white/10 overflow-hidden">
+    <div className="rounded-lg border border-border overflow-hidden">
       <div className="max-h-[calc(100vh-300px)] overflow-y-auto">
         <Table>
           <TableHeader className="sticky top-0 bg-background z-10">
-            <TableRow className="border-white/10 hover:bg-white/5">
-              <TableHead className="text-white bg-background">Symbol</TableHead>
-              <TableHead className="text-white bg-background">Sector</TableHead>
-              <TableHead className="text-white bg-background">Market Cap</TableHead>
-              <TableHead className="text-white bg-background">Recommendation</TableHead>
-              <TableHead className="text-white bg-background">Report</TableHead>
-              <TableHead className="text-white bg-background">Last Updated</TableHead>
-              <TableHead className="text-white bg-background">Action</TableHead>
+            <TableRow className="border-border hover:bg-accent">
+              <TableHead className="text-foreground bg-background">Symbol</TableHead>
+              <TableHead className="text-foreground bg-background">Sector</TableHead>
+              <TableHead className="text-foreground bg-background">Market Cap</TableHead>
+              <TableHead className="text-foreground bg-background">Recommendation</TableHead>
+              <TableHead className="text-foreground bg-background">Report</TableHead>
+              <TableHead className="text-foreground bg-background">Last Updated</TableHead>
+              <TableHead className="text-foreground bg-background">Action</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {Array.from({ length: rows }).map((_, index) => (
-              <TableRow key={index} className="border-white/10 hover:bg-white/5">
+              <TableRow key={index} className="border-border hover:bg-accent">
                 <TableCell>
-                  <Skeleton className="h-4 w-16 bg-white/10" />
+                  <Skeleton className="h-4 w-16 bg-foreground/10" />
                 </TableCell>
                 <TableCell>
-                  <Skeleton className="h-4 w-24 bg-white/10" />
+                  <Skeleton className="h-4 w-24 bg-foreground/10" />
                 </TableCell>
                 <TableCell>
-                  <Skeleton className="h-4 w-20 bg-white/10" />
+                  <Skeleton className="h-4 w-20 bg-foreground/10" />
                 </TableCell>
                 <TableCell>
-                  <Skeleton className="h-6 w-20 rounded-full bg-white/10" />
+                  <Skeleton className="h-6 w-20 rounded-full bg-foreground/10" />
                 </TableCell>
                 <TableCell>
-                  <Skeleton className="h-8 w-24 rounded bg-white/10" />
+                  <Skeleton className="h-8 w-24 rounded bg-foreground/10" />
                 </TableCell>
                 <TableCell>
-                  <Skeleton className="h-4 w-20 bg-white/10" />
+                  <Skeleton className="h-4 w-20 bg-foreground/10" />
                 </TableCell>
                 <TableCell>
-                  <Skeleton className="h-8 w-8 rounded bg-white/10" />
+                  <Skeleton className="h-8 w-8 rounded bg-foreground/10" />
                 </TableCell>
               </TableRow>
             ))}

--- a/src/components/features/table-skeleton.tsx
+++ b/src/components/features/table-skeleton.tsx
@@ -19,15 +19,15 @@ export function TableSkeleton({ rows = 10 }: TableSkeletonProps) {
     <div className="rounded-lg border border-white/10 overflow-hidden">
       <div className="max-h-[calc(100vh-300px)] overflow-y-auto">
         <Table>
-          <TableHeader className="sticky top-0 bg-[#15162c] z-10">
+          <TableHeader className="sticky top-0 bg-background z-10">
             <TableRow className="border-white/10 hover:bg-white/5">
-              <TableHead className="text-white bg-[#15162c]">Symbol</TableHead>
-              <TableHead className="text-white bg-[#15162c]">Sector</TableHead>
-              <TableHead className="text-white bg-[#15162c]">Market Cap</TableHead>
-              <TableHead className="text-white bg-[#15162c]">Recommendation</TableHead>
-              <TableHead className="text-white bg-[#15162c]">Report</TableHead>
-              <TableHead className="text-white bg-[#15162c]">Last Updated</TableHead>
-              <TableHead className="text-white bg-[#15162c]">Action</TableHead>
+              <TableHead className="text-white bg-background">Symbol</TableHead>
+              <TableHead className="text-white bg-background">Sector</TableHead>
+              <TableHead className="text-white bg-background">Market Cap</TableHead>
+              <TableHead className="text-white bg-background">Recommendation</TableHead>
+              <TableHead className="text-white bg-background">Report</TableHead>
+              <TableHead className="text-white bg-background">Last Updated</TableHead>
+              <TableHead className="text-white bg-background">Action</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/src/components/features/valuation-chart.tsx
+++ b/src/components/features/valuation-chart.tsx
@@ -123,8 +123,8 @@ export const ValuationChart = () => {
     return (
       <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
-          <div className="h-6 w-48 rounded bg-gray-700" />
-          <div className="h-[400px] w-full rounded bg-gray-700" />
+          <div className="h-6 w-48 rounded bg-muted" />
+          <div className="h-[400px] w-full rounded bg-muted" />
         </div>
       </div>
     );

--- a/src/components/features/valuation-chart.tsx
+++ b/src/components/features/valuation-chart.tsx
@@ -18,13 +18,13 @@ import { api } from "~/trpc/react";
 type Tab = "valuation" | "ratios";
 
 const TabToggle = ({ tab, onChange }: { tab: Tab; onChange: (t: Tab) => void }) => (
-  <div className="flex overflow-hidden rounded border border-[#424975] text-xs">
+  <div className="flex overflow-hidden rounded border border-border text-xs">
     <button
       onClick={() => onChange("valuation")}
       className={cn(
         "px-3 py-1 transition-colors",
         tab === "valuation"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -35,7 +35,7 @@ const TabToggle = ({ tab, onChange }: { tab: Tab; onChange: (t: Tab) => void }) 
       className={cn(
         "px-3 py-1 transition-colors",
         tab === "ratios"
-          ? "bg-[#424975] text-white"
+          ? "bg-secondary text-white"
           : "text-gray-400 hover:text-gray-200",
       )}
     >
@@ -58,7 +58,7 @@ interface TooltipProps {
 const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded border border-[#424975] bg-[#151624] p-3 text-sm shadow-lg">
+    <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
       <p className="mb-1 font-medium text-gray-200">{formatQuarter(label ?? "")}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.stroke }}>
@@ -121,7 +121,7 @@ export const ValuationChart = () => {
 
   if (isLoading) {
     return (
-      <div className="h-full w-full animate-pulse bg-[#121327]">
+      <div className="h-full w-full animate-pulse bg-secondary">
         <div className="flex h-full flex-col items-center justify-center gap-4">
           <div className="h-6 w-48 rounded bg-gray-700" />
           <div className="h-[400px] w-full rounded bg-gray-700" />

--- a/src/components/features/valuation-chart.tsx
+++ b/src/components/features/valuation-chart.tsx
@@ -24,8 +24,8 @@ const TabToggle = ({ tab, onChange }: { tab: Tab; onChange: (t: Tab) => void }) 
       className={cn(
         "px-3 py-1 transition-colors",
         tab === "valuation"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       Valuation
@@ -35,8 +35,8 @@ const TabToggle = ({ tab, onChange }: { tab: Tab; onChange: (t: Tab) => void }) 
       className={cn(
         "px-3 py-1 transition-colors",
         tab === "ratios"
-          ? "bg-secondary text-white"
-          : "text-gray-400 hover:text-gray-200",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-gray-200",
       )}
     >
       Ratios

--- a/src/components/features/valuation-chart.tsx
+++ b/src/components/features/valuation-chart.tsx
@@ -25,7 +25,7 @@ const TabToggle = ({ tab, onChange }: { tab: Tab; onChange: (t: Tab) => void }) 
         "px-3 py-1 transition-colors",
         tab === "valuation"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       Valuation
@@ -36,7 +36,7 @@ const TabToggle = ({ tab, onChange }: { tab: Tab; onChange: (t: Tab) => void }) 
         "px-3 py-1 transition-colors",
         tab === "ratios"
           ? "bg-secondary text-foreground"
-          : "text-muted-foreground hover:text-gray-200",
+          : "text-muted-foreground hover:text-muted-foreground",
       )}
     >
       Ratios
@@ -59,7 +59,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded border border-border bg-background p-3 text-sm shadow-lg">
-      <p className="mb-1 font-medium text-gray-200">{formatQuarter(label ?? "")}</p>
+      <p className="mb-1 font-medium text-muted-foreground">{formatQuarter(label ?? "")}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.stroke }}>
           {entry.name}: {entry.value?.toFixed(2)}x
@@ -140,7 +140,7 @@ export const ValuationChart = () => {
     <div className="w-full">
       <div className="flex items-center justify-between px-4 pt-2">
         <div className="w-24" />
-        <h2 className="text-center text-xl font-semibold text-gray-200">{title}</h2>
+        <h2 className="text-center text-xl font-semibold text-muted-foreground">{title}</h2>
         <TabToggle tab={tab} onChange={setTab} />
       </div>
       <ResponsiveContainer width="100%" height={480}>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+/**
+ * Theme provider wired to the @mtosity/design-system tokens, which key dark
+ * mode off `[data-theme="dark"]` on <html>. Defaults to dark.
+ */
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return (
+    <NextThemesProvider
+      attribute="data-theme"
+      defaultTheme="dark"
+      enableSystem={false}
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "~/components/ui/button";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+    >
+      {/* Render nothing theme-specific until mounted to avoid hydration mismatch */}
+      {mounted && isDark ? (
+        <Sun className="h-5 w-5" />
+      ) : (
+        <Moon className="h-5 w-5" />
+      )}
+    </Button>
+  );
+}

--- a/src/components/ui/back-button.tsx
+++ b/src/components/ui/back-button.tsx
@@ -10,7 +10,7 @@ export function BackButton({ href = "/", label = "Back" }: BackButtonProps) {
   return (
     <Link
       href={href}
-      className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-white/10 hover:text-white"
+      className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
     >
       <ArrowLeft className="h-4 w-4" />
       {label}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-foreground underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -28,7 +28,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow-sm focus:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-foreground shadow-sm focus:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -27,6 +27,22 @@
   }
 }
 
+/*
+  thestockie light-theme modernization — override the design-system's warm
+  cream palette with a cleaner, cooler neutral set (crisp white page, cool
+  slate surfaces + text). The shadcn tokens reference these vars, so they all
+  re-derive. Dark theme + the lime accent are untouched. (mtosity.com keeps the
+  cream palette; promote this into the package if both should modernize.)
+*/
+:root {
+  --bg: #ffffff;
+  --bg-secondary: #f4f5f7;
+  --fg: #0f172a;
+  --border: #0f172a;
+  --border-light: #e4e7ec;
+  --muted: #64748b;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -27,16 +27,6 @@
   }
 }
 
-/*
-  thestockie: lift the card surface off the cream page. The design-system's
-  --bg-secondary (cards / popovers / muted surfaces) is a darker beige that
-  read as a dull gray box; use a clean warm near-white so cards sit brighter
-  than the page. Everything else keeps the design-system cream palette.
-*/
-:root {
-  --bg-secondary: #fbfaf6;
-}
-
 @layer base {
   * {
     @apply border-border;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,61 +1,71 @@
-@import 'tailwindcss';
+@import "tailwindcss";
+@import "@mtosity/design-system/tokens.css";
 
-@plugin 'tailwindcss-animate';
-@plugin '@tailwindcss/typography';
+@plugin "tailwindcss-animate";
+@plugin "@tailwindcss/typography";
 
-@custom-variant dark (&:is(.dark *));
+/*
+  Bridge: map shadcn's semantic tokens onto the @mtosity/design-system palette
+  (--bg / --fg / --accent / --muted / --border-light …). Those source vars flip
+  automatically under [data-theme="dark"] (provided by the package), so every
+  shadcn component re-skins for free in both themes.
 
+  Semantic choices for the brutalist look:
+  - primary  = lime accent (prominent buttons / active states)
+  - accent   = subtle surface (shadcn uses it for hover states)
+  - borders  = the soft border, not the near-black/cream hard border
+*/
 @theme {
-  --font-sans:
-    var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --color-background: var(--bg);
+  --color-foreground: var(--fg);
 
-  --radius-lg: var(--radius);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-sm: calc(var(--radius) - 4px);
+  --color-card: var(--bg-secondary);
+  --color-card-foreground: var(--fg);
 
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
+  --color-popover: var(--bg-secondary);
+  --color-popover-foreground: var(--fg);
 
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
+  --color-primary: var(--accent);
+  --color-primary-foreground: var(--accent-fg);
 
-  --color-popover: hsl(var(--popover));
-  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-secondary: var(--bg-secondary);
+  --color-secondary-foreground: var(--fg);
 
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-muted: var(--bg-secondary);
+  --color-muted-foreground: var(--muted);
 
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-accent: var(--bg-secondary);
+  --color-accent-foreground: var(--fg);
 
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-destructive: var(--danger);
+  --color-destructive-foreground: #ffffff;
 
-  --color-accent: hsl(var(--accent));
-  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-border: var(--border-light);
+  --color-input: var(--border-light);
+  --color-ring: var(--accent);
 
-  --color-destructive: hsl(var(--destructive));
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
 
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
+  --color-sidebar: var(--bg-secondary);
+  --color-sidebar-foreground: var(--fg);
+  --color-sidebar-primary: var(--accent);
+  --color-sidebar-primary-foreground: var(--accent-fg);
+  --color-sidebar-accent: var(--bg);
+  --color-sidebar-accent-foreground: var(--fg);
+  --color-sidebar-border: var(--border-light);
+  --color-sidebar-ring: var(--accent);
 
-  --color-chart-1: hsl(var(--chart-1));
-  --color-chart-2: hsl(var(--chart-2));
-  --color-chart-3: hsl(var(--chart-3));
-  --color-chart-4: hsl(var(--chart-4));
-  --color-chart-5: hsl(var(--chart-5));
+  /* Brutalist: square corners */
+  --radius-lg: 0px;
+  --radius-md: 0px;
+  --radius-sm: 0px;
 
-  --color-sidebar: hsl(var(--sidebar-background));
-  --color-sidebar-foreground: hsl(var(--sidebar-foreground));
-  --color-sidebar-primary: hsl(var(--sidebar-primary));
-  --color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
-  --color-sidebar-accent: hsl(var(--sidebar-accent));
-  --color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
-  --color-sidebar-border: hsl(var(--sidebar-border));
-  --color-sidebar-ring: hsl(var(--sidebar-ring));
+  /* Inter is the brand sans (provided via next/font as --font-inter) */
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
@@ -79,94 +89,43 @@
 }
 
 /*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
+  Data-viz palette (legible on both warm-black and cream backgrounds).
+  Kept separate from the brand palette so charts stay distinguishable.
 */
+:root {
+  --chart-1: #a3e635;
+  --chart-2: #38bdf8;
+  --chart-3: #fbbf24;
+  --chart-4: #f06a7e;
+  --chart-5: #a78bfa;
+  --radius: 0px;
+}
+
+/*
+  The package's tokens.css hard-sets --color-accent / --color-border /
+  --color-muted (with a [data-theme="dark"] override) for its OWN utilities.
+  Those names collide with shadcn's, so re-assert our mapping at matching
+  specificity for the dark theme.
+*/
+[data-theme="dark"] {
+  --color-accent: var(--bg-secondary);
+  --color-accent-foreground: var(--fg);
+  --color-border: var(--border-light);
+  --color-input: var(--border-light);
+  --color-muted: var(--bg-secondary);
+  --color-muted-foreground: var(--muted);
+}
+
 @layer base {
   *,
   ::after,
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
+    border-color: var(--color-border, currentcolor);
   }
 }
 
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 10% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-  .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-}
 @layer base {
   * {
     @apply border-border;
@@ -188,49 +147,22 @@
   bottom: 3px;
   width: 12px;
   height: 12px;
-  border-right: 2px solid #fffff9;
-  border-bottom: 2px solid #fffff9;
+  border-right: 2px solid var(--border-light);
+  border-bottom: 2px solid var(--border-light);
 }
 
-.react-grid-item > .react-resizable-handle:after {
-  content: "";
-  position: absolute;
-  right: 3px;
-  bottom: 3px;
-  width: 12px;
-  height: 12px;
-  border-right: 2px solid #fffff9;
-  border-bottom: 2px solid #fffff9;
-}
-
-.react-resizable-handle-se {
-  border-right: 2px solid #515a91 !important;
-  border-bottom: 2px solid #515a91 !important;
-}
-
-.react-resizable-handle-sw {
-  border-right: 2px solid #515a91 !important;
-  border-bottom: 2px solid #515a91 !important;
-}
-
-.react-resizable-handle-ne {
-  border-right: 2px solid #515a91 !important;
-  border-bottom: 2px solid #515a91 !important;
-}
-
+.react-resizable-handle-se,
+.react-resizable-handle-sw,
+.react-resizable-handle-ne,
 .react-resizable-handle-nw {
-  border-right: 2px solid #515a91 !important;
-  border-bottom: 2px solid #515a91 !important;
+  border-right: 2px solid var(--muted) !important;
+  border-bottom: 2px solid var(--muted) !important;
 }
 
 .react-resizable-handle {
   background: none !important;
   width: 12px !important;
   height: 12px !important;
-}
-
-body {
-  background: #15162c;
 }
 
 /* Syntax highlighting for code blocks (github-dark theme) */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,72 +1,11 @@
 @import "tailwindcss";
-@import "@mtosity/design-system/tokens.css";
+@import "@mtosity/design-system/shadcn.css";
 
 @plugin "tailwindcss-animate";
 @plugin "@tailwindcss/typography";
 
-/*
-  Bridge: map shadcn's semantic tokens onto the @mtosity/design-system palette
-  (--bg / --fg / --accent / --muted / --border-light …). Those source vars flip
-  automatically under [data-theme="dark"] (provided by the package), so every
-  shadcn component re-skins for free in both themes.
-
-  Semantic choices for the brutalist look:
-  - primary  = lime accent (prominent buttons / active states)
-  - accent   = subtle surface (shadcn uses it for hover states)
-  - borders  = the soft border, not the near-black/cream hard border
-*/
+/* shadcn accordion animations */
 @theme {
-  --color-background: var(--bg);
-  --color-foreground: var(--fg);
-
-  --color-card: var(--bg-secondary);
-  --color-card-foreground: var(--fg);
-
-  --color-popover: var(--bg-secondary);
-  --color-popover-foreground: var(--fg);
-
-  --color-primary: var(--accent);
-  --color-primary-foreground: var(--accent-fg);
-
-  --color-secondary: var(--bg-secondary);
-  --color-secondary-foreground: var(--fg);
-
-  --color-muted: var(--bg-secondary);
-  --color-muted-foreground: var(--muted);
-
-  --color-accent: var(--bg-secondary);
-  --color-accent-foreground: var(--fg);
-
-  --color-destructive: var(--danger);
-  --color-destructive-foreground: #ffffff;
-
-  --color-border: var(--border-light);
-  --color-input: var(--border-light);
-  --color-ring: var(--accent);
-
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-
-  --color-sidebar: var(--bg-secondary);
-  --color-sidebar-foreground: var(--fg);
-  --color-sidebar-primary: var(--accent);
-  --color-sidebar-primary-foreground: var(--accent-fg);
-  --color-sidebar-accent: var(--bg);
-  --color-sidebar-accent-foreground: var(--fg);
-  --color-sidebar-border: var(--border-light);
-  --color-sidebar-ring: var(--accent);
-
-  /* Brutalist: square corners */
-  --radius-lg: 0px;
-  --radius-md: 0px;
-  --radius-sm: 0px;
-
-  /* Inter is the brand sans (provided via next/font as --font-inter) */
-  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
-
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
 
@@ -85,44 +24,6 @@
     to {
       height: 0;
     }
-  }
-}
-
-/*
-  Data-viz palette (legible on both warm-black and cream backgrounds).
-  Kept separate from the brand palette so charts stay distinguishable.
-*/
-:root {
-  --chart-1: #a3e635;
-  --chart-2: #38bdf8;
-  --chart-3: #fbbf24;
-  --chart-4: #f06a7e;
-  --chart-5: #a78bfa;
-  --radius: 0px;
-}
-
-/*
-  The package's tokens.css hard-sets --color-accent / --color-border /
-  --color-muted (with a [data-theme="dark"] override) for its OWN utilities.
-  Those names collide with shadcn's, so re-assert our mapping at matching
-  specificity for the dark theme.
-*/
-[data-theme="dark"] {
-  --color-accent: var(--bg-secondary);
-  --color-accent-foreground: var(--fg);
-  --color-border: var(--border-light);
-  --color-input: var(--border-light);
-  --color-muted: var(--bg-secondary);
-  --color-muted-foreground: var(--muted);
-}
-
-@layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-border, currentcolor);
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -28,19 +28,13 @@
 }
 
 /*
-  thestockie light-theme modernization — override the design-system's warm
-  cream palette with a cleaner, cooler neutral set (crisp white page, cool
-  slate surfaces + text). The shadcn tokens reference these vars, so they all
-  re-derive. Dark theme + the lime accent are untouched. (mtosity.com keeps the
-  cream palette; promote this into the package if both should modernize.)
+  thestockie: lift the card surface off the cream page. The design-system's
+  --bg-secondary (cards / popovers / muted surfaces) is a darker beige that
+  read as a dull gray box; use a clean warm near-white so cards sit brighter
+  than the page. Everything else keeps the design-system cream palette.
 */
 :root {
-  --bg: #ffffff;
-  --bg-secondary: #f4f5f7;
-  --fg: #0f172a;
-  --border: #0f172a;
-  --border-light: #e4e7ec;
-  --muted: #64748b;
+  --bg-secondary: #fbfaf6;
 }
 
 @layer base {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -15,7 +15,7 @@
 
 /* Mermaid chart text overrides — force bright readable text */
 .mermaid-container text {
-  fill: #e2e8f0 !important;
+  fill: var(--fg) !important;
 }
 
 .mermaid-container .tick text,
@@ -23,11 +23,11 @@
 .mermaid-container .xAxisLabel,
 .mermaid-container .yAxisLabel,
 .mermaid-container .legend text {
-  fill: #cbd5e1 !important;
+  fill: var(--muted) !important;
 }
 
 .mermaid-container .title {
-  fill: #f1f5f9 !important;
+  fill: var(--fg) !important;
 }
 
 /* Axis lines and ticks */


### PR DESCRIPTION
## Summary

Consumes the newly published **`@mtosity/design-system@0.1.0`** (GitHub Packages) and re-skins thestockie with the portfolio's warm-black + lime brutalist palette. **Dark by default**, with a working light/dark toggle.

## How it works
- `.npmrc` points the `@mtosity` scope at GitHub Packages; Vercel authenticates via the `NODE_AUTH_TOKEN` env var (set on all environments).
- `globals.css` imports `@mtosity/design-system/tokens.css` and **bridges shadcn's semantic tokens onto the portfolio palette** (`--bg`/`--fg`/`--accent`/`--muted`/`--border-light`). Those source vars flip under `[data-theme="dark"]`, so every shadcn component re-skins in both themes for free.
  - `primary` = lime accent, square corners (`--radius: 0`), soft borders.
  - Re-asserts the `accent`/`border`/`muted` token-name collisions for the dark theme (the package emits its own same-named utilities).
- `layout.tsx` loads **Inter / Crimson Text / Lora** via `next/font` and wraps the app in a `next-themes` provider keyed to `[data-theme]`, `defaultTheme="dark"`.
- New `ThemeProvider` + `ThemeToggle` (toggle lives in the navbar).

## Dark re-skin
- Replaced all hardcoded navy/purple hexes (`#15162c`/`#151624`/`#121327`/`#1e1f36`/`#424975`) with tokens (`bg-background`/`bg-secondary`/`border-border`/…) across pages + feature components.
- Recharts grid strokes now use `var(--border-light)`.

## Verification
- ✅ `pnpm build` passes locally (28 routes).
- Vercel preview to confirm visually.

## Follow-up (not in this PR)
The **light** theme still needs the `text-white` / `bg-white` / `border-white` sweep (~370 occurrences). They read fine on the dark background, so they're deferred to keep this PR focused on the dark migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)