### PR TITLE
style(cards): alpaca strategy-card chrome on /influencers & /blogs

### DIFF
--- a/src/app/influencers/page.tsx
+++ b/src/app/influencers/page.tsx
@@ -28,7 +28,7 @@ function LoadingState() {
 
 function EmptyState() {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardContent className="flex flex-col items-center gap-3 py-16 text-center">
         <Inbox className="h-10 w-10 text-gray-600" />
         <h2 className="text-lg font-semibold">No influencer data yet</h2>

--- a/src/components/features/blog-card.tsx
+++ b/src/components/features/blog-card.tsx
@@ -18,9 +18,7 @@ export function BlogCard({ blog, className }: BlogCardProps) {
     <Link href={`/blogs/${frontmatter.slug}`} className="group block">
       <Card
         className={cn(
-          "h-full overflow-hidden border-border bg-foreground/5 transition-all duration-300",
-          "hover:border-border hover:bg-accent hover:shadow-xl hover:shadow-primary/20",
-          "hover:-translate-y-1",
+          "strategy-card strategy-card-interactive h-full overflow-hidden text-card-foreground",
           className
         )}
       >

--- a/src/components/features/influencer-digest.tsx
+++ b/src/components/features/influencer-digest.tsx
@@ -53,7 +53,7 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
   ].filter(Boolean);
 
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
         <div>
           <h2 className="text-lg font-semibold">Daily Market Digest</h2>

--- a/src/components/features/influencer-roster.tsx
+++ b/src/components/features/influencer-roster.tsx
@@ -61,7 +61,7 @@ export function InfluencerRoster({
   influencers: Influencer[];
 }) {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="pb-3">
         <h2 className="text-sm font-semibold">Tracked creators ({(influencers?.length ?? 0)})</h2>
       </CardHeader>

--- a/src/components/features/influencer-sentiment.tsx
+++ b/src/components/features/influencer-sentiment.tsx
@@ -110,7 +110,7 @@ function LeaderCard({
   empty: string;
 }) {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="space-y-0 pb-3">
         <div className={`flex items-center gap-2 text-sm font-semibold ${accent}`}>
           {icon} {title}

--- a/src/components/features/influencer-videos.tsx
+++ b/src/components/features/influencer-videos.tsx
@@ -55,7 +55,7 @@ function VideoRow({ video }: { video: Video }) {
 
 export function RecentInfluencerVideos({ videos }: { videos: Video[] }) {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="pb-3">
         <h2 className="text-sm font-semibold">Recently analyzed</h2>
       </CardHeader>

--- a/src/components/features/super-investor-consensus.tsx
+++ b/src/components/features/super-investor-consensus.tsx
@@ -98,7 +98,7 @@ function Side({
   empty: string;
 }) {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="space-y-0 pb-3">
         <div className={`flex items-center gap-2 text-sm font-semibold ${accent}`}>
           {icon} {title}

--- a/src/components/features/super-investor-moves.tsx
+++ b/src/components/features/super-investor-moves.tsx
@@ -67,7 +67,7 @@ function MoveCard({
   kind: "buy" | "sell";
 }) {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="space-y-0 pb-3">
         <div
           className={`flex items-center gap-2 text-sm font-semibold ${accent}`}

--- a/src/components/features/super-investor-roster.tsx
+++ b/src/components/features/super-investor-roster.tsx
@@ -57,7 +57,7 @@ function InvestorCard({ inv }: { inv: Investor }) {
 
 export function InvestorRoster({ investors }: { investors: Investor[] }) {
   return (
-    <Card className="border-border bg-foreground/5 text-foreground">
+    <Card className="strategy-card text-card-foreground">
       <CardHeader className="pb-3">
         <h3 className="text-sm font-semibold">Tracked investors ({(investors?.length ?? 0)})</h3>
       </CardHeader>

--- a/src/components/features/super-investor-section.tsx
+++ b/src/components/features/super-investor-section.tsx
@@ -48,7 +48,7 @@ export function SuperInvestorsSection() {
           <Skeleton className="h-56 w-full rounded-xl bg-foreground/5" />
         </div>
       ) : !hasData ? (
-        <Card className="border-border bg-foreground/5 text-foreground">
+        <Card className="strategy-card text-card-foreground">
           <CardContent className="py-12 text-center text-sm text-muted-foreground">
             No 13F data yet — run the superinvestor-job.
           </CardContent>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -36,6 +36,22 @@
   }
 }
 
+/* Always-on card chrome, mirroring alpaca's `.strategy-card` hover state:
+   a strong border (near-white on dark, near-black on light) plus a brutalist
+   offset shadow — shown directly rather than only on hover. Both colors come
+   from the design-system `--border` token so they track the active theme. */
+.strategy-card {
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-brutal);
+  transition:
+    box-shadow 0.15s,
+    transform 0.15s;
+}
+.strategy-card-interactive:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: var(--shadow-brutal-lg);
+}
+
 * {
   animation-fill-mode: forwards;
   -webkit-animation-fill-mode: forwards;


### PR DESCRIPTION
## What

Give the cards on **/influencers** and **/blogs** the same look as the `.strategy-card` on alpaca.mtosity.com/strategies: a **strong border** (near-white on dark, near-black on light) plus a **brutalist offset shadow** — shown **directly**, not only on hover.

## How

The alpaca card reveals this chrome on hover:
```css
.strategy-card:hover { border-color: var(--border); box-shadow: var(--shadow-brutal); }
```
This PR makes that the default state. Added to `src/styles/globals.css`:
```css
.strategy-card {
  border: 1px solid var(--border);     /* #f2efe8 on dark, #0d0d0d on light */
  box-shadow: var(--shadow-brutal);    /* 4px 4px 0 var(--border) */
}
.strategy-card-interactive:hover { transform: translate(-1px,-1px); box-shadow: var(--shadow-brutal-lg); }
```
Both colors come from the design-system `--border` token, so they track the active light/dark theme. (Note: Tailwind's `border-border` maps to the *faint* `--border-light`, which is why the previous cards looked subtle.)

### Applied to
- **/influencers**: digest, sentiment leaderboard, roster, recent videos, super-investor moves/consensus/roster, empty states
- **/blogs**: blog cards (with an optional hover lift via `strategy-card-interactive`)

## Verification
- Rendered locally with real data; white border + offset shadow show on every card (screenshots shared with author).
- `tsc --noEmit`: no new errors over the `main` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)