### PR TITLE
feat(chart): show live quoting only on the 1D view

### DIFF
--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -215,9 +215,9 @@ export function Chart() {
       enabled: timeFrame === "1D" && !!symbol,
     });
 
-  // Live quote — polled every few seconds for real-time price ticks.
+  // Live quote — only on the 1D view; polled every few seconds for ticks.
   const { data: liveQuoteData } = api.asset.equityQuote.useQuery(symbol ?? "", {
-    enabled: !!symbol,
+    enabled: !!symbol && timeFrame === "1D",
     refetchInterval: 5000,
     refetchIntervalInBackground: false,
   });
@@ -308,9 +308,12 @@ export function Chart() {
       .slice(0, 10);
   }, [indicatorData, indicators.sr, activeChartData]);
 
-  /* ── live-quote overlay ── */
+  /* ── live-quote overlay (1D view only) ── */
   const isLive =
-    livePrice != null && !Number.isNaN(livePrice) && activeChartData.length > 0;
+    timeFrame === "1D" &&
+    livePrice != null &&
+    !Number.isNaN(livePrice) &&
+    activeChartData.length > 0;
 
   // Overlay the live price onto the last point so the line tip tracks it live.
   const liveMergedData = useMemo(() => {


### PR DESCRIPTION
## What

Follow-up to #47 — the live quoting only activates when the **1D** timeframe is selected.

- The quote poll is `enabled` only when `timeFrame === "1D"` (no background polling on 5Y/1Y/… views).
- `isLive` requires `timeFrame === "1D"`, which gates the whole live overlay: LIVE badge, pulsing line-end dot, the flashing/rolling price, and the live last-point. Other timeframes render the static historical price.

Performance line coloring (green/red) is unchanged — it stays on all timeframes.

## Verification

Rendered locally: 1Y shows a static price with no LIVE badge; clicking 1D brings up the LIVE badge + live overlay (screenshots shared). No new type errors over baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)