### PR TITLE
perf(home): prioritized panel loading + fix 1D to current trading day

### DIFF
--- a/shot_1dperf.mjs
+++ b/shot_1dperf.mjs
@@ -1,0 +1,16 @@
+import puppeteer from "puppeteer-core";
+const b = await puppeteer.launch({ executablePath:"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", headless:"new", defaultViewport:{width:1300,height:900,deviceScaleFactor:2}, args:["--no-sandbox","--hide-scrollbars"] });
+const p = await b.newPage();
+// count network requests to the trpc endpoint over the first 3s
+let reqs=0; p.on("request", r => { if(r.url().includes("/api/trpc")) reqs++; });
+await p.goto("http://localhost:3000/",{waitUntil:"domcontentloaded",timeout:60000});
+await new Promise(r=>setTimeout(r,3000));
+console.log("trpc batch requests in first 3s:", reqs);
+// click 1D and capture the chart's x-axis (should be a single day)
+await p.waitForFunction(()=>document.querySelector(".recharts-wrapper"),{timeout:20000}).catch(()=>{});
+await p.evaluate(()=>{const d=[...document.querySelectorAll("button")].find(b=>b.textContent.trim()==="1D"); d&&d.click();});
+await new Promise(r=>setTimeout(r,4000));
+const el=await p.$(".recharts-wrapper");
+if(el) await el.screenshot({path:"/tmp/perf_1d.png"});
+console.log("saved");
+await b.close();

--- a/src/components/features/chart.tsx
+++ b/src/components/features/chart.tsx
@@ -241,7 +241,7 @@ export function Chart() {
 
   const chartData2: ChartDataPoint[] = useMemo(() => {
     if (!data2?.results) return [];
-    return data2.results.map((r) => ({
+    const mapped = data2.results.map((r) => ({
       date: r.date,
       price: r.close,
       open: r.open,
@@ -250,6 +250,17 @@ export function Chart() {
       close: r.close,
       volume: r.volume,
     }));
+    if (mapped.length === 0) return mapped;
+    // FMP's 1-min endpoint returns several days of intraday bars; the 1D view
+    // should show only the latest (current) trading session. Keep bars on the
+    // most recent calendar day, oldest→newest.
+    const latestDay = mapped.reduce(
+      (max, r) => (r.date.slice(0, 10) > max ? r.date.slice(0, 10) : max),
+      "",
+    );
+    return mapped
+      .filter((r) => r.date.slice(0, 10) === latestDay)
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   }, [data2]);
 
   const activeChartData: ChartDataPoint[] = useMemo(() => {

--- a/src/components/features/deferred-mount.tsx
+++ b/src/components/features/deferred-mount.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+/**
+ * Defers mounting a panel (and therefore its data fetching) so the homepage
+ * can load the priority widgets first — main chart, news, market indices,
+ * company profile — then fill in the rest without a single network burst.
+ *
+ * A deferred panel mounts when EITHER:
+ *  - it scrolls within ~300px of the viewport (IntersectionObserver), or
+ *  - the browser goes idle, at which point a shared scheduler releases a few
+ *    panels per idle tick so off-screen widgets trickle in after the critical
+ *    content rather than all at once.
+ */
+
+type Release = () => void;
+
+// Shared idle drip across all deferred panels.
+const queue: Release[] = [];
+let draining = false;
+
+const onIdle: (cb: () => void) => number =
+  typeof window !== "undefined" && "requestIdleCallback" in window
+    ? (cb) => window.requestIdleCallback(cb, { timeout: 2000 })
+    : (cb) => window.setTimeout(cb, 200);
+
+function drain() {
+  if (draining) return;
+  draining = true;
+  const step = () => {
+    if (queue.length === 0) {
+      draining = false;
+      return;
+    }
+    // Release a small batch per idle tick so requests stay staggered.
+    queue.splice(0, 2).forEach((fn) => fn());
+    onIdle(step);
+  };
+  onIdle(step);
+}
+
+function enqueue(fn: Release) {
+  queue.push(fn);
+  drain();
+}
+
+function dequeue(fn: Release) {
+  const i = queue.indexOf(fn);
+  if (i >= 0) queue.splice(i, 1);
+}
+
+export function DeferredMount({
+  children,
+  eager = false,
+}: {
+  children: ReactNode;
+  eager?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [show, setShow] = useState(eager);
+
+  useEffect(() => {
+    if (eager || show) return;
+    const el = ref.current;
+    const reveal = () => setShow(true);
+
+    let io: IntersectionObserver | undefined;
+    if (el && "IntersectionObserver" in window) {
+      io = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) reveal();
+        },
+        { rootMargin: "300px" },
+      );
+      io.observe(el);
+    }
+
+    enqueue(reveal);
+
+    return () => {
+      io?.disconnect();
+      dequeue(reveal);
+    };
+  }, [eager, show]);
+
+  return (
+    <div ref={ref} className="h-full w-full">
+      {show ? (
+        children
+      ) : (
+        <div className="h-full w-full animate-pulse bg-foreground/[0.02]" />
+      )}
+    </div>
+  );
+}

--- a/src/components/features/grid.tsx
+++ b/src/components/features/grid.tsx
@@ -30,6 +30,7 @@ import { ValuationChart } from "./valuation-chart";
 import { StockPeers } from "./stock-peers";
 import { InsiderTrading } from "./insider-trading";
 import { AnalystRatings } from "./analyst-ratings";
+import { DeferredMount } from "./deferred-mount";
 
 const Grid = () => {
   const { width, height } = useWindowSize();
@@ -56,11 +57,12 @@ const Grid = () => {
         isDraggable={false}
         resizeHandles={["se", "sw", "ne", "nw"]}
       >
+        {/* Priority widgets — load first (main chart, news, company profile).
+            Market indices (DOW/S&P/NASDAQ) live in the navbar and load eagerly
+            too. Everything else is deferred until it scrolls into view or the
+            browser is idle, so the critical content isn't starved on load. */}
         <div key="main-chart" className={clx}>
           <Chart />
-        </div>
-        <div key="fundamental-pillars" className={clx}>
-          <Fundamentals />
         </div>
         <div key="news" className={clx}>
           <News />
@@ -68,65 +70,103 @@ const Grid = () => {
         <div key="live-quote" className={clx}>
           <CompanyProfile />
         </div>
+
+        <div key="fundamental-pillars" className={clx}>
+          <DeferredMount>
+            <Fundamentals />
+          </DeferredMount>
+        </div>
         <div key="ai" className={clx}>
-          <GPT />
+          <DeferredMount>
+            <GPT />
+          </DeferredMount>
         </div>
 
         {/* Income Statement */}
         <div key="revenue" className={clx}>
-          <Revenue />
+          <DeferredMount>
+            <Revenue />
+          </DeferredMount>
         </div>
         <div key="ebitda" className={clx}>
-          <EBITDA />
+          <DeferredMount>
+            <EBITDA />
+          </DeferredMount>
         </div>
         <div key="net-income" className={clx}>
-          <NetIncome />
+          <DeferredMount>
+            <NetIncome />
+          </DeferredMount>
         </div>
         <div key="eps" className={clx}>
-          <EPS />
+          <DeferredMount>
+            <EPS />
+          </DeferredMount>
         </div>
         <div key="expenses" className={clx}>
-          <Expenses />
+          <DeferredMount>
+            <Expenses />
+          </DeferredMount>
         </div>
 
         {/* Balance Sheet */}
         <div key="balance-growth" className={clx}>
-          <BalanceGrowth />
+          <DeferredMount>
+            <BalanceGrowth />
+          </DeferredMount>
         </div>
         <div key="cash-debt" className={clx}>
-          <CashDebt />
+          <DeferredMount>
+            <CashDebt />
+          </DeferredMount>
         </div>
 
         {/* Cash Flow */}
         <div key="cash-growth" className={clx}>
-          <CashGrowth />
+          <DeferredMount>
+            <CashGrowth />
+          </DeferredMount>
         </div>
         <div key="dividends" className={clx}>
-          <Dividends />
+          <DeferredMount>
+            <Dividends />
+          </DeferredMount>
         </div>
 
         {/* Capital Structure */}
         <div key="shares-outstanding" className={clx}>
-          <SharesOutstanding />
+          <DeferredMount>
+            <SharesOutstanding />
+          </DeferredMount>
         </div>
 
         {/* Valuation & Ratios */}
         <div key="valuation" className={clx}>
-          <ValuationChart />
+          <DeferredMount>
+            <ValuationChart />
+          </DeferredMount>
         </div>
         <div key="margin-trends" className={clx}>
-          <MarginTrends />
+          <DeferredMount>
+            <MarginTrends />
+          </DeferredMount>
         </div>
 
         {/* Competitive & Risk Analysis */}
         <div key="stock-peers" className={clx}>
-          <StockPeers />
+          <DeferredMount>
+            <StockPeers />
+          </DeferredMount>
         </div>
         <div key="analyst-ratings" className={clx}>
-          <AnalystRatings />
+          <DeferredMount>
+            <AnalystRatings />
+          </DeferredMount>
         </div>
         <div key="insider-trading" className={clx}>
-          <InsiderTrading />
+          <DeferredMount>
+            <InsiderTrading />
+          </DeferredMount>
         </div>
       </GridLayout>
       <div className="pb-20"></div>


### PR DESCRIPTION
## Why

The home page mounted ~20 data-fetching panels simultaneously, firing a request burst that competed with the widgets that matter first.

## Performance — prioritized loading

- New **`DeferredMount`** wrapper: a panel mounts (and therefore fetches) only when it scrolls within ~300px of the viewport **or** when the browser goes idle. A shared `requestIdleCallback` drip releases a few deferred panels per idle tick, so off-screen widgets trickle in *after* the critical content instead of all at once.
- **Eager (load first):** main chart, news, company profile. The DOW / S&P 500 / NASDAQ indices already load eagerly in the navbar.
- **Deferred:** fundamentals, AI summary, and all income-statement / balance-sheet / cash-flow / valuation / peers / ratings / insider panels.
- Measured: initial tRPC batch requests on load drop from ~one-per-panel to **3**; the page still fully renders (verified — all charts/tables populate via idle drip + on-scroll).

react-grid-layout positions items by their `key`, so wrapping children doesn't change the visual layout.

## Bug fix — 1D shows a single session

FMP's `historical-chart/1min` endpoint returns several days of intraday bars with no date range, so the **1D** view was rendering multiple days. Now it keeps only the most recent trading session (latest calendar day), sorted oldest→newest. Verified: x-axis spans 09:30 AM → 03:59 PM.

## Verification

Rendered locally: 1D shows one session; home page loads priority widgets first then fills in the rest with real data. No new type errors over the repo baseline. Screenshots shared with author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)