### PR TITLE
blog: Semiconductors — trim, hold, or chase the 2026 AI capital rotation?

### DIFF
--- a/content/blogs/semiconductors-trim-or-hold-2026-ai-capital-rotation.mdx
+++ b/content/blogs/semiconductors-trim-or-hold-2026-ai-capital-rotation.mdx
@@ -1,0 +1,156 @@
+---
+title: "Semiconductors at the Summit: Trim, Hold, or Chase the 2026 AI Capital Rotation?"
+slug: "semiconductors-trim-or-hold-2026-ai-capital-rotation"
+excerpt: "MU has 10x'd, AMD has run past its price targets, and NVDA is consolidating below its 50-day. Meanwhile SpaceX, OpenAI, and Anthropic are about to vacuum up trillions in public capital. A data-driven look at whether to trim semis — and the underrated power, grid, and uranium plays nobody is talking about."
+coverImage: "https://images.unsplash.com/photo-1518770660439-4636190af475?w=1200&h=630&fit=crop"
+tags: ["Stocks", "Analysis", "AI"]
+publishedAt: "2026-06-26"
+---
+
+# Semiconductors at the Summit: Trim, Hold, or Chase the 2026 AI Capital Rotation?
+
+Two years into the AI buildout, the semiconductor trade is no longer a single trade. Some chip names are dangerously parabolic, some have outrun every analyst on the Street, and one has quietly stalled. At the same time, the largest wave of private-to-public listings in market history — SpaceX, OpenAI, Anthropic — is about to pull marginal capital straight out of the names that benefited from it. This report separates the signal from the euphoria.
+
+## Executive Summary
+
+- **Micron (MU)** has gone vertical — roughly a **10x move off its 52-week low**, now trading ~45% above its 50-day and ~173% above its 200-day moving average. Yet forward earnings remain so strong that consensus still sees ~30% more upside. This is the hardest call on the board: **trim the parabola, hold a core.**
+- **AMD** at ~$520 is already trading **above its $468 average analyst price target** — the market has run past the fundamentals. **Trim into strength.**
+- **NVIDIA** at a $4.7T market cap is **consolidating below its 50-day** — leadership digestion, not breakdown. **Hold, don't chase.**
+- The **H2 2026 IPO supercycle** (SpaceX ~$1.5T, OpenAI ~$852B, Anthropic ~$965B) is a mechanical headwind: a finite pool of growth capital is being asked to fund the *sources* of AI, not just its *suppliers*.
+- The real asymmetric opportunity is in the **overlooked second-derivative plays**: nuclear & uranium, electrical grid and transmission, and an energy sector trading at less than half the multiple of tech.
+
+---
+
+## Part 1 — The Semiconductor Scoreboard
+
+*All prices and data as of June 26, 2026 (FMP API).*
+
+| Ticker | Price | Today | 52-Wk Range | vs 50-DMA | vs 200-DMA | Mkt Cap | FMP Rating | Signal |
+|--------|-------|-------|-------------|-----------|------------|---------|------------|--------|
+| **MU** | $1,147 | 🔴 -5.4% | $103 – $1,255 | +45% | +173% | $1.29T | A- | 🟡 TRIM & HOLD |
+| **AMD** | $520 | 🔴 -2.4% | $134 – $563 | +20% | +93% | $848B | B | 🟠 TRIM |
+| **NVDA** | $194 | 🔴 -0.8% | $151 – $237 | -8% | +2% | $4.70T | — | 🟢 HOLD |
+| **AVGO** | $368 | 🔴 -3.0% | $263 – $495 | -11% | +2% | $1.75T | — | 🟢 HOLD |
+| **TSM** | $431 | 🔴 -0.8% | $221 – $477 | +5% | +27% | $2.24T | — | 🟢 HOLD |
+| **INTC** | $128 | 🔴 -3.6% | $19 – $141 | +20% | +122% | $644B | — | 🟡 TRIM |
+| **ARM** | $329 | 🔴 -5.3% | $100 – $453 | +17% | +91% | $350B | — | 🟠 TRIM |
+| **SMCI** | $31 | 🔴 -3.7% | $19 – $62 | -9% | -14% | $20B | — | 🔴 AVOID |
+
+The whole complex was red on the session — a useful tell. When the leaders can't hold a green tape on good news, distribution is usually underway.
+
+### MU — Micron: The Hardest Call on the Board
+
+**Signal: 🟡 TRIM THE PARABOLA, HOLD A CORE | FMP Rating: A- (overall 4/5)**
+
+| Attribute | Detail |
+|-----------|--------|
+| Price | $1,147 (−5.4% today) |
+| 52-Week Range | $103 → $1,255 |
+| Distance above 200-DMA | +173% |
+| Consensus Target | $1,497 (median $1,500) |
+| Target Range | $400 – $2,200 |
+| Grades | 57 Buy / 11 Hold / 2 Sell |
+
+Micron is the purest expression of the **AI memory supercycle**. High-bandwidth memory (HBM) capacity is reportedly *sold out through calendar 2026*, with the HBM TAM forecast to compound ~40% toward $100B by 2028. Remarkably, despite the stock's near-vertical chart, forward valuation has stayed compressed (commentary pegs it near ~8x non-GAAP forward earnings) because profits and margins have risen even faster than the share price.
+
+So you have a genuine paradox: **technically euphoric, fundamentally still not expensive.** That is exactly the kind of setup that punishes both the people who sell everything *and* the people who chase with size.
+
+- **The bull case:** structural shortage, HBM4 yields acting as a natural barrier to oversupply, 30% implied upside to a $1,500 consensus.
+- **The bear case:** memory is *the* most cyclical corner of tech. The phrase "today's shortage is tomorrow's glut" exists because of DRAM. A stock 173% above its 200-day prices in a lot of perfection, and the $400–$2,200 target range tells you analysts have no real idea how the cycle ends.
+
+**The disciplined move:** scale out of a portion into the strength, ratchet a stop under the 50-day, and let a core position ride the secular story. You do not need to be a hero on a name that has already made the year.
+
+### AMD — The Market Has Outrun the Analysts
+
+**Signal: 🟠 TRIM | FMP Rating: B (overall 3/5)**
+
+AMD at ~$520 is trading **~10% above its $468 average price target** and above the $450 median. Wall Street is still constructive (50 Buy, 20 Hold, **0 Sell**), but price has simply run ahead of where the modeled fundamentals sit today. When a stock is above consensus, you are no longer being paid to take new risk — you're betting analysts chase you higher. That is a momentum trade, not a value trade, and it should be sized and stopped like one. **Trim; keep a runner only with a defined stop.**
+
+### NVIDIA — The Giant Catches Its Breath
+
+**Signal: 🟢 HOLD**
+
+The $4.7T anchor of the AI trade is the tell for the whole group: NVDA sits ~8% *below* its 50-day and barely above its 200-day. After a historic run, this looks like digestion, not distribution — but a mega-cap that has stopped making new highs is rarely the place to add aggressively. **Hold the core; let it base.**
+
+---
+
+## Part 2 — The Capital Magnet: Why the Sources of AI Are Going Public
+
+Here is the rotation almost nobody is positioning for. For two years, public investors expressed the AI thesis through its *suppliers* — chips, networking, power. In the second half of 2026, the *sources* of AI demand are coming public at once, and they are enormous:
+
+| Company | Valuation | Status | Notes |
+|---------|-----------|--------|-------|
+| **SpaceX** (incl. xAI) | ~$1.5T target | IPO ~June 2026 | Would be the **largest IPO in history**; Starlink ~61% of revenue, xAI merged in at a combined ~$1.25T |
+| **OpenAI** | ~$852B | Confidential filing; fall 2026 debut | Following a record ~$122B raise |
+| **Anthropic** | ~$965B | Confidentially filed; fall 2026 | **~$47B revenue run-rate**, powered by Claude Code; briefly the most valuable AI startup |
+
+Three listings, each seeking a **trillion-dollar-class** valuation, landing in a single six-month window. The growth-capital pool is large but not infinite. When index funds, growth managers, and retail all have to make room for SpaceX, OpenAI, and Anthropic, the funding has to come *from somewhere* — and the most obvious donor is the basket of AI-beneficiary semis that have already delivered 2–10x returns and now screen as "crowded longs."
+
+This does not break the semis. It does cap the *marginal* bid and raise the bar: from here, chip names have to grow into valuations while competing for capital against the very companies driving their order books. **Rotation, not collapse.**
+
+---
+
+## Part 3 — The Underrated Sectors Nobody Is Watching
+
+Strip out the headline names and the most interesting setups are in the unglamorous second derivative of AI — the physical bottlenecks — plus the cheapest corners of the market.
+
+### Sector Tape & Valuation (NASDAQ, June 25, 2026)
+
+| Sector | 1-Day Move | P/E | Read |
+|--------|-----------|-----|------|
+| Basic Materials | 🟢 +1.5% | 30.8 | Quiet bid returning |
+| Healthcare | 🟢 +0.7% | 23.2 | Defensive rotation |
+| Communication Services | 🟢 +0.5% | 23.8 | Mixed |
+| Energy | 🔴 -0.1% | **16.9** | **Cheapest sector in the market** |
+| Financials | 🔴 -1.3% | 18.6 | IPO-fee tailwind under the surface |
+| Technology | 🔴 **-1.7%** | **47.9** | Most expensive, worst performer |
+
+Money came *out* of the most expensive sector (Tech, ~48x) and *into* materials and defensives on the day. That is the rotation in miniature.
+
+### 1. ⚛️ Nuclear & Uranium — The Only 24/7 Answer to AI Power
+
+Data-center electricity demand is projected to climb from ~460 TWh (2022) toward **1,000+ TWh by 2026**, and Goldman Sachs estimates data-center power demand could rise **~160% by 2030**. AI training clusters need *firm, always-on* power — and at scale, that points to nuclear. Microsoft, Google, Amazon, and Meta are already signing reactor deals or funding new builds. The catch: **uranium supply is one of the most constrained commodity chains on earth**, and it cannot ramp on the same timeline demand is exploding. Accelerating demand into inelastic supply is the textbook setup for a multi-year commodity bull. *Underowned by generalists; expressed via uranium miners, nuclear utilities, and SMR developers.*
+
+### 2. 🔌 The Electrical Grid, Transmission & Gas Turbines
+
+Before a single GPU runs, the electricity has to get there. NextEra alone is exploring **$25B+ in new transmission**, and gas-turbine and electrical-equipment makers are seeing their valuations re-rate toward AI. This is the "picks and shovels of the picks and shovels" — transformers, switchgear, high-voltage cable, and turbine OEMs. Boring, capital-intensive, and structurally short of capacity.
+
+### 3. 🛢️ Energy — Hiding in Plain Sight at 17x
+
+Energy is simultaneously **the cheapest sector in the market (PE ~17)** and the *binding constraint* on the entire AI buildout. Natural gas is the bridge fuel for firm power; pipelines and gas-fired generation feed the data centers nuclear can't reach in time. You are being asked to pay a recession multiple for a structural-growth catalyst. That asymmetry rarely persists.
+
+### 4. 🏦 Financials — The Quiet IPO-Fee Bonanza
+
+Every trillion-dollar IPO is an underwriting, advisory, and trading windfall. The same listing wave that pressures crowded semis pays the investment banks and exchanges directly. At ~19x, financials are not pricing in the fee supercycle that SpaceX, OpenAI, and Anthropic are about to deliver.
+
+---
+
+## Part 4 — What the Library Says: Timeless Wisdom for a Euphoric Tape
+
+When a position has 10x'd, the hardest input isn't data — it's temperament. A few principles from the canon (and from our own RAG finance library) that apply directly here:
+
+- **Morgan Housel, *The Psychology of Money*** — *Getting* wealthy and *staying* wealthy are different skills. The first rewards optimism and risk; the second rewards humility and fear. After a 10x, your job switches from the first game to the second. Trim.
+- **Benjamin Graham, *The Intelligent Investor*** — Mr. Market is manic. A 173%-above-trend chart is Mr. Market in a manic phase, *offering* to buy your shares at a euphoric price. "Price is what you pay; value is what you get." Let him pay up for part of your position.
+- **Aswath Damodaran, *The Little Book of Valuation*** — A great company is not a great stock at any price. MU and AMD can be excellent businesses *and* poor entries on the same day.
+- **Daniel Kahneman, *Thinking, Fast and Slow*** — Recency bias makes the last two years feel like the next two. Overconfidence peaks at tops. Pre-commit to a trim plan now, before the next green candle re-recruits your optimism.
+- **Peter Lynch, *One Up on Wall Street*** — Know what you own and rotate toward where the story is *early*. The semis story is mature and widely known; the grid, uranium, and energy stories are early and under-followed.
+
+---
+
+## Bottom Line
+
+| Action | Names | Rationale |
+|--------|-------|-----------|
+| 🟡 **Trim & Hold** | MU | Parabolic technically, cheap fundamentally — take partial profits, keep a stopped core |
+| 🟠 **Trim** | AMD, ARM, INTC | Price above (or stretched vs) where fundamentals and analysts sit |
+| 🟢 **Hold** | NVDA, AVGO, TSM | Digesting gains; own it, don't add aggressively |
+| 🔴 **Avoid** | SMCI | Below 50- and 200-day; broken structure |
+| 🚀 **Rotate Into** | Uranium/Nuclear, Grid/Transmission, Energy (17x), Financials | Underowned second-derivative AI plays + cheapest sectors |
+
+The semiconductor trade isn't over — but the *easy* part is. From here it is a stock-picker's and risk-manager's market: take profits where the chart has outrun the fundamentals (AMD), respect the secular story where it's still intact (MU core, NVDA, TSM), and put fresh capital to work in the unglamorous bottlenecks the crowd is ignoring. And keep some dry powder: when SpaceX, OpenAI, and Anthropic hit the tape this fall, the best opportunities may be in what gets *sold* to make room for them.
+
+**Trim the euphoria. Respect the trend. Rotate toward the overlooked.**
+
+---
+
+*Data sourced from FMP API and web research; prices as of June 26, 2026. Valuations for SpaceX, OpenAI, and Anthropic reflect private-market and reported IPO figures and are subject to change. Investing-wisdom references draw on TheStockie finance library (Housel, Graham, Damodaran, Kahneman, Lynch). This is not financial advice — do your own research and size positions to your own risk tolerance.*


### PR DESCRIPTION
## Summary
New MDX blog post: **Semiconductors at the Summit: Trim, Hold, or Chase the 2026 AI Capital Rotation?**

`content/blogs/semiconductors-trim-or-hold-2026-ai-capital-rotation.mdx` (~2,200 words, ~9 min read)

Answers the three questions directly, grounded in **live FMP market data** (prices as of 2026-06-26) and web research.

### What it covers
1. **Semis scoreboard — trim or buy?** Live quotes, MA distances, analyst targets & ratings for MU, AMD, NVDA, AVGO, TSM, INTC, ARM, SMCI.
   - **MU** $1,147 — ~10x off its low, +173% vs 200-DMA, but consensus PT still $1,500 → **trim the parabola, hold a core**.
   - **AMD** $520 — already **above** its $468 consensus target → **trim**.
   - **NVDA** $4.7T — consolidating below its 50-DMA → **hold, don't chase**.
2. **Capital rotation to private AI/space.** The H2 2026 IPO supercycle — **SpaceX (~$1.5T), OpenAI (~$852B), Anthropic (~$965B, ~$47B run-rate)** — as a mechanical headwind pulling marginal capital out of crowded semis.
3. **Underrated sectors nobody's watching.** Nuclear & uranium (AI's only 24/7 firm power), electrical grid/transmission & gas turbines, energy (cheapest sector at ~17x), and financials (IPO-fee bonanza).
4. **Wisdom layer** from the finance book library (Housel, Graham, Damodaran, Kahneman, Lynch).

### Format / validation
- Matches existing post conventions (gray-matter frontmatter, signal tables, emoji ratings, disclaimer footer).
- Frontmatter validated (title/slug/excerpt/coverImage/tags/publishedAt); slug matches filename; no MDX-breaking characters.
- Tags: `Stocks`, `Analysis`, `AI`.

> Not financial advice — analysis/education only.