### PR TITLE
macro: fix VIX & Dollar Index to 1Y, remove Carry Trade card + timeframe caption

### DIFF
--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -111,33 +111,6 @@ function formatLargeNumber(n: number): string {
 
 // ── TimeFrame Selector ──────────────────────────────────────────────
 
-function TimeFrameSelector({
-  value,
-  onChange,
-}: {
-  value: MacroTimeFrame;
-  onChange: (tf: MacroTimeFrame) => void;
-}) {
-  const options: MacroTimeFrame[] = ["1D", "1W", "1M", "1Y"];
-  return (
-    <div className="inline-flex rounded-lg border border-border bg-background p-0.5">
-      {options.map((tf) => (
-        <button
-          key={tf}
-          onClick={() => onChange(tf)}
-          className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
-            value === tf
-              ? "bg-foreground/10 text-foreground shadow-xs"
-              : "text-muted-foreground hover:text-muted-foreground"
-          }`}
-        >
-          {tf}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 // ── Change calculation from historical data ─────────────────────────
 
 function useHistoricalChange(
@@ -1380,7 +1353,6 @@ function CommoditiesCard() {
 // ── Main Dashboard ──────────────────────────────────────────────────
 
 export function MacroDashboard() {
-  const [timeFrame, setTimeFrame] = useState<MacroTimeFrame>("1Y");
   const mounted = useMounted();
 
   if (!mounted) {
@@ -1397,50 +1369,43 @@ export function MacroDashboard() {
   }
 
   return (
-    <TimeFrameContext.Provider value={timeFrame}>
-      <div className="p-4">
-        {/* Sticky timeframe selector */}
-        <div className="mb-4 flex items-center justify-end">
-          <TimeFrameSelector value={timeFrame} onChange={setTimeFrame} />
+    <div className="p-4">
+      {/* Fed & economic data — one chart with a dropdown switcher */}
+      <div className="mb-4">
+        <MacroFedDataBlock />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {/* Row 1: Key indicators */}
+        <VixCard />
+        <DollarIndexCard />
+        <TreasuryCard />
+
+        {/* Row 2: Markets — overlaid 1Y line charts */}
+        <MacroLineCard title="Global Market Indices" syms={INDICES} kind="indices" />
+        <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />
+        <MacroLineCard title="Commodities" syms={COMMODITIES_GROUP} kind="commodities" />
+        <MacroLineCard title="Crypto" syms={CRYPTO} kind="crypto" />
+
+        {/* Sector rotation over time (same width as Market News below) */}
+        <div className="md:col-span-2 xl:col-span-2">
+          <SectorRotation />
         </div>
 
-        {/* Fed & economic data — one chart with a dropdown switcher */}
-        <div className="mb-4">
-          <MacroFedDataBlock />
+        {/* Bottom: left column (risk gauges + upcoming econ events) and
+            Market News spanning that column's full height and width. */}
+        <div className="flex flex-col gap-4">
+          <FearGreedCard />
+          <EconomicCalendarCard />
         </div>
-
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {/* Row 1: Key indicators */}
-          <VixCard />
-          <DollarIndexCard />
-          <TreasuryCard />
-
-          {/* Row 2: Markets — overlaid 1Y line charts */}
-          <MacroLineCard title="Global Market Indices" syms={INDICES} kind="indices" />
-          <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />
-          <MacroLineCard title="Commodities" syms={COMMODITIES_GROUP} kind="commodities" />
-          <MacroLineCard title="Crypto" syms={CRYPTO} kind="crypto" />
-
-          {/* Sector rotation over time (same width as Market News below) */}
-          <div className="md:col-span-2 xl:col-span-2">
-            <SectorRotation />
-          </div>
-
-          {/* Bottom: left column (risk gauges + upcoming econ events) and
-              Market News spanning that column's full height and width. */}
-          <div className="flex flex-col gap-4">
-            <FearGreedCard />
-            <EconomicCalendarCard />
-          </div>
-          {/* On xl, News fills the left column's height (absolute) and scrolls
-              internally; on smaller screens it flows naturally full-width. */}
-          <div className="md:col-span-2 xl:relative xl:col-span-2">
-            <div className="xl:absolute xl:inset-0">
-              <GeneralNewsCard />
-            </div>
+        {/* On xl, News fills the left column's height (absolute) and scrolls
+            internally; on smaller screens it flows naturally full-width. */}
+        <div className="md:col-span-2 xl:relative xl:col-span-2">
+          <div className="xl:absolute xl:inset-0">
+            <GeneralNewsCard />
           </div>
         </div>
       </div>
-    </TimeFrameContext.Provider>
+    </div>
   );
 }

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -228,7 +228,7 @@ const VIX_LEVELS = [
 ] as const;
 
 function VixCard() {
-  const timeFrame = useContext(TimeFrameContext);
+  const timeFrame: MacroTimeFrame = "1Y";
   const { data, isLoading } = api.asset.equityQuote.useQuery(
     "^VIX",
     REFETCH_OPTS,
@@ -454,7 +454,7 @@ function FearGreedCard() {
 // ── US Dollar Index (DXY) ───────────────────────────────────────────
 
 function DollarIndexCard() {
-  const timeFrame = useContext(TimeFrameContext);
+  const timeFrame: MacroTimeFrame = "1Y";
   const { data, isLoading } = api.asset.equityQuote.useQuery(
     "DXUSD",
     REFETCH_OPTS,
@@ -554,80 +554,6 @@ function DollarIndexCard() {
 }
 
 // ── Carry Trade & Risk (compact) ────────────────────────────────────
-
-function CarryRiskCard() {
-  const timeFrame = useContext(TimeFrameContext);
-
-  const { data: jpy, isLoading: jpyLoading } = api.asset.forexQuote.useQuery(
-    "USDJPY",
-    REFETCH_OPTS,
-  );
-  const { data: jpyHist } = api.asset.forexHistorical.useQuery(
-    "USDJPY",
-    REFETCH_OPTS,
-  );
-  const jpyRate = jpy?.bid ?? jpy?.ask ?? 0;
-  const { changePercent: jpyChange } = useHistoricalChange(
-    jpyHist?.historical,
-    jpyRate || undefined,
-    timeFrame,
-  );
-
-  const { data: btc } = api.asset.equityQuote.useQuery("BTCUSD", REFETCH_OPTS);
-  const { data: btcHist } = api.asset.equityPriceHistoricalFMP.useQuery(
-    "BTCUSD",
-    REFETCH_OPTS,
-  );
-  const btcQuote = btc?.[0];
-  const { changePercent: btcChange } = useHistoricalChange(
-    btcHist?.historical,
-    btcQuote?.price ?? undefined,
-    timeFrame,
-  );
-
-  return (
-    <CardShell title="Carry Trade & Risk">
-      {jpyLoading ? (
-        <SkeletonRows count={3} />
-      ) : (
-        <div>
-          <div className="flex items-center justify-between border-b border-border py-2">
-            <div>
-              <span className="text-sm font-medium text-foreground">USD/JPY</span>
-              <span className="ml-2 text-xs text-muted-foreground">Yen Carry</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-muted-foreground">
-                ¥{jpyRate.toFixed(2)}
-              </span>
-              <ChangeDisplay
-                changePercent={jpyChange}
-                className="min-w-[60px] text-right text-xs"
-              />
-            </div>
-          </div>
-          <div className="mt-2 flex items-center justify-between py-2">
-            <div>
-              <span className="text-sm font-medium text-foreground">Bitcoin</span>
-              <span className="ml-2 text-xs text-muted-foreground">Risk Sentiment</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-muted-foreground">
-                {btcQuote?.price
-                  ? `$${formatLargeNumber(btcQuote.price)}`
-                  : "—"}
-              </span>
-              <ChangeDisplay
-                changePercent={btcChange}
-                className="min-w-[60px] text-right text-xs"
-              />
-            </div>
-          </div>
-        </div>
-      )}
-    </CardShell>
-  );
-}
 
 // ── Global Market Indices ───────────────────────────────────────────
 
@@ -1474,10 +1400,7 @@ export function MacroDashboard() {
     <TimeFrameContext.Provider value={timeFrame}>
       <div className="p-4">
         {/* Sticky timeframe selector */}
-        <div className="mb-4 flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">
-            Showing % change over selected period
-          </span>
+        <div className="mb-4 flex items-center justify-end">
           <TimeFrameSelector value={timeFrame} onChange={setTimeFrame} />
         </div>
 
@@ -1506,7 +1429,6 @@ export function MacroDashboard() {
           {/* Bottom: left column (risk gauges + upcoming econ events) and
               Market News spanning that column's full height and width. */}
           <div className="flex flex-col gap-4">
-            <CarryRiskCard />
             <FearGreedCard />
             <EconomicCalendarCard />
           </div>


### PR DESCRIPTION
## Summary
Macro dashboard cleanup (`src/components/features/macro-dashboard.tsx`):

1. **VixCard** and **DollarIndexCard** fixed to a **1Y** window — no longer read `TimeFrameContext` (applies to both the `% change` calc and chart point-count).
2. **Removed the "Carry Trade & Risk" card** (USD/JPY + BTC) — definition + render site.
3. **Removed the "Showing % change over selected period" caption**.
4. **Removed the now-unused `TimeFrameSelector`** — its usage and definition, the `timeFrame` `useState`, and the `TimeFrameContext.Provider` wrapper. With VIX/Dollar pinned to 1Y, the Carry card gone, and the `MacroLineCard` line charts already hardcoded to 1Y, the selector controlled nothing rendered.

## Notes
- `TimeFrameContext` itself is retained (still referenced by the pre-existing, unrendered legacy components `IndexRow`/`ForexRow`/`CommodityRow`/`SectorPerformanceCard`) so nothing breaks. Those were already dead code before this PR; left untouched. Can remove in a follow-up if desired.
- Type-checked by inspection (`MacroTimeFrame` includes `"1Y"`); this workspace copy has no `node_modules`, so relying on CI for `pnpm check`.