### PR TITLE
macro: add Finviz-style stock heatmap (squarified treemap)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,10 @@ const config = {
         protocol: "https",
         hostname: "images.unsplash.com",
       },
+      {
+        protocol: "https",
+        hostname: "assets.parqet.com",
+      },
     ],
   },
 };

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -554,7 +554,13 @@ function SectorRRG({ rows }: { rows: Row[] }) {
     const sy = std(allY, my);
     const norm = series.map((s) => ({
       ...s,
-      pts: s.pts.map((p) => ({ x: (p.x - mx) / sx, y: (p.y - my) / sy })),
+      pts: s.pts.map((p, k, arr) => ({
+        x: (p.x - mx) / sx,
+        y: (p.y - my) / sy,
+        first: k === 0,
+        last: k === arr.length - 1,
+        prog: arr.length > 1 ? k / (arr.length - 1) : 1,
+      })),
     }));
     const maxAbs = Math.max(
       1.5,
@@ -586,10 +592,12 @@ function SectorRRG({ rows }: { rows: Row[] }) {
                 isAnimationActive={false}
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 shape={(props: any) => {
-                  const total = s.pts.length;
-                  const i = props.index as number;
-                  const isLast = i === total - 1;
-                  const isFirst = i === 0;
+                  // recharts doesn't pass `index` to Scatter shapes, so we read
+                  // the start/end/progress metadata off the data point itself.
+                  const pt = props.payload ?? {};
+                  const isLast = !!pt.last;
+                  const isFirst = !!pt.first;
+                  const prog = typeof pt.prog === "number" ? pt.prog : 1;
                   // Hollow ring marks the start (oldest); the trail grows in
                   // size + opacity toward the solid "now" dot at the end.
                   if (isFirst && !isLast) {
@@ -597,22 +605,21 @@ function SectorRRG({ rows }: { rows: Row[] }) {
                       <circle
                         cx={props.cx}
                         cy={props.cy}
-                        r={3}
+                        r={4}
                         fill="none"
                         stroke={s.color}
-                        strokeWidth={1.5}
-                        strokeOpacity={0.8}
+                        strokeWidth={2}
+                        strokeOpacity={0.9}
                       />
                     );
                   }
-                  const prog = total > 1 ? i / (total - 1) : 1;
                   return (
                     <circle
                       cx={props.cx}
                       cy={props.cy}
-                      r={isLast ? 5 : 1.5 + prog * 2.5}
+                      r={isLast ? 6 : 2 + prog * 2.5}
                       fill={s.color}
-                      fillOpacity={isLast ? 1 : 0.3 + prog * 0.6}
+                      fillOpacity={isLast ? 1 : 0.35 + prog * 0.55}
                     />
                   );
                 }}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -702,97 +702,7 @@ export function SectorRotation() {
 }
 
 
-// ── Stock Heatmap (squarified treemap) ──────────────────────────────
-
-interface HeatmapStock {
-  symbol: string;
-  name: string;
-  sector: string;
-  marketCap: number;
-  change: number | null;
-}
-
-interface Rect {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
-
-/** Squarified treemap (Bruls et al.). Lays weighted items into the given rect
- *  so tile aspect ratios stay close to 1. Coordinates are in the same units as
- *  the input rect (we use a 0–100 percentage space for responsive rendering). */
-function squarify<T extends { value: number }>(
-  data: T[],
-  X: number,
-  Y: number,
-  W: number,
-  H: number,
-): (T & Rect)[] {
-  const out: (T & Rect)[] = [];
-  const items = data.filter((d) => d.value > 0).sort((a, b) => b.value - a.value);
-  const total = items.reduce((s, d) => s + d.value, 0);
-  if (total <= 0 || W <= 0 || H <= 0) return out;
-
-  const scale = (W * H) / total;
-  const vals = items.map((d) => ({ d, area: d.value * scale }));
-
-  let rx = X,
-    ry = Y,
-    rw = W,
-    rh = H;
-  let row: { d: T; area: number }[] = [];
-
-  const worst = (r: typeof row, side: number) => {
-    const sum = r.reduce((s, q) => s + q.area, 0);
-    const mx = Math.max(...r.map((q) => q.area));
-    const mn = Math.min(...r.map((q) => q.area));
-    const s2 = sum * sum;
-    const l2 = side * side;
-    return Math.max((l2 * mx) / s2, s2 / (l2 * mn));
-  };
-
-  const layout = (r: typeof row, vertical: boolean) => {
-    const sum = r.reduce((s, q) => s + q.area, 0);
-    if (vertical) {
-      const colW = sum / rh;
-      let oy = ry;
-      for (const q of r) {
-        const cellH = q.area / colW;
-        out.push({ ...q.d, x: rx, y: oy, w: colW, h: cellH });
-        oy += cellH;
-      }
-      rx += colW;
-      rw -= colW;
-    } else {
-      const rowH = sum / rw;
-      let ox = rx;
-      for (const q of r) {
-        const cellW = q.area / rowH;
-        out.push({ ...q.d, x: ox, y: ry, w: cellW, h: rowH });
-        ox += cellW;
-      }
-      ry += rowH;
-      rh -= rowH;
-    }
-  };
-
-  let i = 0;
-  while (i < vals.length) {
-    const vertical = rw >= rh;
-    const side = vertical ? rh : rw;
-    const next = [...row, vals[i]!];
-    if (row.length === 0 || worst(row, side) >= worst(next, side)) {
-      row = next;
-      i++;
-    } else {
-      layout(row, vertical);
-      row = [];
-    }
-  }
-  if (row.length) layout(row, rw >= rh);
-  return out;
-}
+// ── Stock Heatmap (sector-ranked square grid) ───────────────────────
 
 /** Tile background: green for gains, red for losses, intensity scaled by
  *  magnitude (capped at ±4%). Matches the SectorHeatmap color convention. */
@@ -816,46 +726,22 @@ function fmtPct(change: number | null): string {
   return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
 }
 
-/** Finviz-style market map: largest US companies as a squarified treemap,
- *  grouped by sector, tiles sized by market cap and colored by today's move. */
+/** Market heatmap as a square grid of equal square tiles, one per company,
+ *  ordered by market cap (largest first), colored by today's % change.
+ *  At xl the grid is 10 columns × 10 rows for the top 100 → a clean square. */
 export function StockHeatmap() {
   const { data, isLoading } = api.asset.stockHeatmap.useQuery(
     { limit: 100 },
     REFETCH,
   );
 
-  // Two-level treemap: partition the canvas among sectors (by total market
-  // cap), then squarify each sector's stocks within its rect.
-  const tiles = useMemo(() => {
+  const stocks = useMemo(() => {
     if (!data?.length) return [];
-    const bySector = new Map<string, HeatmapStock[]>();
-    for (const s of data) {
-      const arr = bySector.get(s.sector) ?? [];
-      arr.push(s);
-      bySector.set(s.sector, arr);
-    }
-    const sectors = [...bySector.entries()].map(([sector, stocks]) => ({
-      sector,
-      stocks,
-      value: stocks.reduce((sum, s) => sum + s.marketCap, 0),
-    }));
-
-    const sectorRects = squarify(sectors, 0, 0, 100, 100);
-    return sectorRects.map((sr) => ({
-      sector: sr.sector,
-      rect: { x: sr.x, y: sr.y, w: sr.w, h: sr.h },
-      stocks: squarify(
-        sr.stocks.map((s) => ({ ...s, value: s.marketCap })),
-        sr.x,
-        sr.y,
-        sr.w,
-        sr.h,
-      ),
-    }));
+    return [...data].sort((a, b) => b.marketCap - a.marketCap);
   }, [data]);
 
   return (
-    <div className="rounded-xl border border-border bg-background p-4">
+    <div className="flex flex-col rounded-xl border border-border bg-background p-4">
       <div className="mb-1 flex items-start justify-between gap-3">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           Market Heatmap
@@ -873,70 +759,37 @@ export function StockHeatmap() {
         </div>
       </div>
       <p className="mb-3 text-xs text-muted-foreground">
-        Top 100 US companies by market cap, grouped by sector. Tile size = market
-        cap, color = today&apos;s move.
+        Top 100 US companies by market cap, ordered largest first, colored by
+        today&apos;s move.
       </p>
 
       {isLoading ? (
-        <div className="flex h-[480px] items-center justify-center text-sm text-muted-foreground">
+        <div className="flex aspect-square items-center justify-center text-sm text-muted-foreground">
           Loading…
         </div>
-      ) : tiles.length === 0 ? (
-        <div className="flex h-[480px] items-center justify-center text-sm text-muted-foreground">
+      ) : stocks.length === 0 ? (
+        <div className="flex aspect-square items-center justify-center text-sm text-muted-foreground">
           No data
         </div>
       ) : (
-        <div className="relative h-[480px] w-full overflow-hidden rounded-lg">
-          {tiles.map(({ sector, rect, stocks }) => (
-            <div key={sector}>
-              {/* sector outline + label */}
-              <div
-                className="pointer-events-none absolute z-10"
-                style={{
-                  left: `${rect.x}%`,
-                  top: `${rect.y}%`,
-                  width: `${rect.w}%`,
-                  height: `${rect.h}%`,
-                }}
-              >
-                <span className="absolute left-1 top-0.5 rounded-sm bg-background/70 px-1 text-[0.6rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                  {sector}
-                </span>
-              </div>
-              {/* stock tiles */}
-              {stocks.map((s) => {
-                const showSym = s.w >= 3 && s.h >= 4;
-                const showPct = s.w >= 4.5 && s.h >= 7;
-                return (
-                  <div
-                    key={s.symbol}
-                    title={`${s.symbol} · ${s.name} · ${fmtCap(
-                      s.marketCap,
-                    )} · ${fmtPct(s.change)}`}
-                    className="absolute flex flex-col items-center justify-center overflow-hidden border border-background/60 text-center"
-                    style={{
-                      left: `${s.x}%`,
-                      top: `${s.y}%`,
-                      width: `${s.w}%`,
-                      height: `${s.h}%`,
-                      background: tileBg(s.change),
-                    }}
-                  >
-                    {showSym && (
-                      <span className="px-0.5 text-[0.7rem] font-bold leading-tight text-foreground">
-                        {s.symbol}
-                      </span>
-                    )}
-                    {showPct && (
-                      <span className="text-[0.6rem] tabular-nums leading-tight text-foreground/80">
-                        {s.change == null
-                          ? "—"
-                          : `${s.change >= 0 ? "+" : ""}${s.change.toFixed(1)}%`}
-                      </span>
-                    )}
-                  </div>
-                );
-              })}
+        <div className="grid grid-cols-6 gap-1 sm:grid-cols-8 xl:grid-cols-10">
+          {stocks.map((s) => (
+            <div
+              key={s.symbol}
+              title={`${s.symbol} · ${s.name} · ${s.sector} · ${fmtCap(
+                s.marketCap,
+              )} · ${fmtPct(s.change)}`}
+              className="flex aspect-square flex-col items-center justify-center overflow-hidden rounded-sm px-0.5 text-center"
+              style={{ background: tileBg(s.change) }}
+            >
+              <span className="w-full truncate text-[0.7rem] font-bold leading-tight text-foreground">
+                {s.symbol}
+              </span>
+              <span className="text-[0.6rem] tabular-nums leading-tight text-foreground/80">
+                {s.change == null
+                  ? "—"
+                  : `${s.change >= 0 ? "+" : ""}${s.change.toFixed(1)}%`}
+              </span>
             </div>
           ))}
         </div>

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -582,12 +582,39 @@ function SectorRRG({ rows }: { rows: Row[] }) {
                 key={s.symbol}
                 data={s.pts}
                 fill={s.color}
-                line={{ stroke: s.color, strokeWidth: 1, strokeOpacity: 0.5 }}
+                line={{ stroke: s.color, strokeWidth: 1.5, strokeOpacity: 0.45 }}
                 isAnimationActive={false}
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 shape={(props: any) => {
-                  const isLast = props.index === s.pts.length - 1;
-                  return <circle cx={props.cx} cy={props.cy} r={isLast ? 5 : 2} fill={s.color} fillOpacity={isLast ? 1 : 0.4} />;
+                  const total = s.pts.length;
+                  const i = props.index as number;
+                  const isLast = i === total - 1;
+                  const isFirst = i === 0;
+                  // Hollow ring marks the start (oldest); the trail grows in
+                  // size + opacity toward the solid "now" dot at the end.
+                  if (isFirst && !isLast) {
+                    return (
+                      <circle
+                        cx={props.cx}
+                        cy={props.cy}
+                        r={3}
+                        fill="none"
+                        stroke={s.color}
+                        strokeWidth={1.5}
+                        strokeOpacity={0.8}
+                      />
+                    );
+                  }
+                  const prog = total > 1 ? i / (total - 1) : 1;
+                  return (
+                    <circle
+                      cx={props.cx}
+                      cy={props.cy}
+                      r={isLast ? 5 : 1.5 + prog * 2.5}
+                      fill={s.color}
+                      fillOpacity={isLast ? 1 : 0.3 + prog * 0.6}
+                    />
+                  );
                 }}
               >
                 <LabelList
@@ -605,6 +632,13 @@ function SectorRRG({ rows }: { rows: Row[] }) {
             ))}
           </ScatterChart>
         </ResponsiveContainer>
+      </div>
+      <div className="mt-1 flex items-center justify-center gap-1.5 text-[0.62rem] text-muted-foreground">
+        <span className="inline-block h-2 w-2 rounded-full border border-muted-foreground" />
+        <span>start</span>
+        <span className="opacity-60">→ trail →</span>
+        <span className="inline-block h-2.5 w-2.5 rounded-full bg-muted-foreground" />
+        <span>now</span>
       </div>
       <div className="mt-1 grid grid-cols-2 text-[0.62rem] text-muted-foreground">
         <span className="text-[#3b82f6]">↖ Improving</span>

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -700,3 +700,132 @@ export function SectorRotation() {
     </div>
   );
 }
+
+// ── Stock Heatmap ───────────────────────────────────────────────────
+
+interface HeatmapStock {
+  symbol: string;
+  name: string;
+  sector: string;
+  marketCap: number;
+  change: number | null;
+}
+
+/** Tile background: green for gains, red for losses, intensity scaled by
+ *  magnitude (capped at ±4%). Matches the SectorHeatmap color convention. */
+function tileBg(change: number | null): string {
+  if (change == null) return "color-mix(in srgb, #64748b 18%, transparent)";
+  const a = Math.round(Math.min(1, Math.abs(change) / 4) * 78) + 8;
+  return change >= 0
+    ? `color-mix(in srgb, #22c55e ${a}%, transparent)`
+    : `color-mix(in srgb, #ef4444 ${a}%, transparent)`;
+}
+
+function fmtCap(n: number): string {
+  if (n >= 1e12) return `$${(n / 1e12).toFixed(2)}T`;
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}B`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(0)}M`;
+  return `$${n}`;
+}
+
+/** Finviz-style market map: largest US companies grouped by sector, each tile
+ *  sized (flex-grow) by market cap and colored by today's % change. */
+export function StockHeatmap() {
+  const { data, isLoading } = api.asset.stockHeatmap.useQuery(
+    { limit: 100 },
+    REFETCH,
+  );
+
+  const sectors = useMemo(() => {
+    if (!data?.length) return [];
+    const bySector = new Map<string, HeatmapStock[]>();
+    for (const s of data) {
+      const arr = bySector.get(s.sector) ?? [];
+      arr.push(s);
+      bySector.set(s.sector, arr);
+    }
+    return [...bySector.entries()]
+      .map(([sector, stocks]) => ({
+        sector,
+        stocks: [...stocks].sort((a, b) => b.marketCap - a.marketCap),
+        total: stocks.reduce((sum, s) => sum + s.marketCap, 0),
+      }))
+      .sort((a, b) => b.total - a.total);
+  }, [data]);
+
+  return (
+    <div className="rounded-xl border border-border bg-background p-4">
+      <div className="mb-1 flex items-start justify-between gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Market Heatmap
+        </h2>
+        <div className="flex items-center gap-1 text-[0.65rem] text-muted-foreground">
+          <span>-4%</span>
+          <span
+            className="inline-block h-2 w-16 rounded-sm"
+            style={{
+              background:
+                "linear-gradient(to right, #ef4444, color-mix(in srgb, #64748b 18%, transparent), #22c55e)",
+            }}
+          />
+          <span>+4%</span>
+        </div>
+      </div>
+      <p className="mb-3 text-xs text-muted-foreground">
+        Top 100 US companies by market cap, grouped by sector. Tile size = market
+        cap, color = today&apos;s move.
+      </p>
+
+      {isLoading ? (
+        <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+          Loading…
+        </div>
+      ) : sectors.length === 0 ? (
+        <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+          No data
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2" style={{ minHeight: 360 }}>
+          {sectors.map(({ sector, stocks, total }) => (
+            <div
+              key={sector}
+              className="flex min-w-[180px] flex-col"
+              style={{ flexGrow: total, flexBasis: 0 }}
+            >
+              <div className="mb-1 truncate text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                {sector}
+              </div>
+              <div className="flex flex-1 flex-wrap content-start gap-1">
+                {stocks.map((s) => (
+                  <div
+                    key={s.symbol}
+                    title={`${s.name} · ${fmtCap(s.marketCap)} · ${
+                      s.change == null
+                        ? "—"
+                        : (s.change >= 0 ? "+" : "") + s.change.toFixed(2) + "%"
+                    }`}
+                    className="flex min-w-[56px] flex-col items-center justify-center rounded px-1 py-1.5 text-center"
+                    style={{
+                      flexGrow: s.marketCap,
+                      flexBasis: 0,
+                      background: tileBg(s.change),
+                    }}
+                  >
+                    <span className="text-xs font-bold text-foreground">
+                      {s.symbol}
+                    </span>
+                    <span className="text-[0.6rem] tabular-nums text-foreground/80">
+                      {s.change == null
+                        ? "—"
+                        : (s.change >= 0 ? "+" : "") + s.change.toFixed(1) + "%"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -357,6 +357,8 @@ function SectorBump({ rows }: { rows: Row[] }) {
       .sort((a, b) => a.rank - b.rank);
   }, [data]);
 
+  const [hovered, setHovered] = useState<string | null>(null);
+
   return (
     <>
       <div style={{ height: 300 }}>
@@ -387,17 +389,49 @@ function SectorBump({ rows }: { rows: Row[] }) {
                 );
               }}
             />
-            {SECTOR_ETFS.map((s, i) => (
-              <Line key={s.symbol} dataKey={s.symbol} name={s.symbol} stroke={sectorColor(i)} strokeWidth={1.5} dot={{ r: 2 }} activeDot={{ r: 4 }} connectNulls isAnimationActive={false} />
-            ))}
+            {SECTOR_ETFS.map((s, i) => {
+              const isHot = hovered === s.symbol;
+              const dimmed = hovered != null && !isHot;
+              const color = sectorColor(i);
+              return (
+                <Line
+                  key={s.symbol}
+                  dataKey={s.symbol}
+                  name={s.symbol}
+                  stroke={color}
+                  strokeWidth={isHot ? 3.25 : 1.5}
+                  strokeOpacity={dimmed ? 0.2 : 1}
+                  dot={dimmed ? false : { r: 2 }}
+                  activeDot={{ r: 4 }}
+                  connectNulls
+                  isAnimationActive={false}
+                  style={
+                    isHot
+                      ? { filter: `drop-shadow(0 0 5px ${color})` }
+                      : undefined
+                  }
+                  onMouseEnter={() => setHovered(s.symbol)}
+                  onMouseLeave={() => setHovered(null)}
+                />
+              );
+            })}
           </LineChart>
         </ResponsiveContainer>
       </div>
       <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
         {ranking.map((s) => (
-          <span key={s.symbol} className="flex items-center gap-1 text-xs">
+          <span
+            key={s.symbol}
+            className="flex cursor-pointer items-center gap-1 text-xs transition-opacity"
+            style={{ opacity: hovered != null && hovered !== s.symbol ? 0.35 : 1 }}
+            onMouseEnter={() => setHovered(s.symbol)}
+            onMouseLeave={() => setHovered(null)}
+          >
             <span className="font-mono text-muted-foreground">{s.rank}</span>
-            <span className="inline-block h-0.5 w-3" style={{ background: sectorColor(s.i) }} />
+            <span
+              className="inline-block h-0.5 w-3"
+              style={{ background: sectorColor(s.i) }}
+            />
             <span className="text-muted-foreground">{s.label}</span>
           </span>
         ))}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -379,9 +379,17 @@ function SectorBump({ rows }: { rows: Row[] }) {
                       .sort((a, b) => a.value - b.value)
                       .map((p) => {
                         const s = SECTOR_ETFS.find((x) => x.symbol === p.name);
+                        const isHot = hovered === p.name;
                         return (
-                          <div key={p.name} style={{ color: p.color }}>
-                            #{p.value} {s?.label ?? p.name}
+                          <div
+                            key={p.name}
+                            className={isHot ? "font-bold" : ""}
+                            style={{
+                              color: p.color,
+                              opacity: hovered != null && !isHot ? 0.45 : 1,
+                            }}
+                          >
+                            {isHot ? "▶ " : ""}#{p.value} {s?.label ?? p.name}
                           </div>
                         );
                       })}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -14,6 +14,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import Image from "next/image";
 import { Select } from "@mtosity/design-system";
 import { ChartTooltip } from "~/components/ui/chart";
 import { api } from "~/trpc/react";
@@ -816,6 +817,24 @@ function fmtPct(change: number | null): string {
   return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
 }
 
+/** Company logo for a heatmap tile (FMP image endpoint). Hides itself if the
+ *  logo 404s — the symbol text below it still identifies the company. */
+function TileLogo({ symbol, size }: { symbol: string; size: number }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return null;
+  return (
+    <Image
+      src={`https://financialmodelingprep.com/image-stock/${symbol}.png`}
+      alt={symbol}
+      width={size}
+      height={size}
+      unoptimized
+      className="mb-0.5 rounded-sm bg-white/90 object-contain p-px"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 /** Finviz/TradingView-style market map: largest US companies as a squarified
  *  treemap, grouped by sector, tiles sized by market cap and colored by today's
  *  move. Fills the height of its column (the 3 stacked charts on the left). */
@@ -908,6 +927,9 @@ export function StockHeatmap() {
               {stocks.map((s) => {
                 const showSym = s.w >= 3 && s.h >= 4;
                 const showPct = s.w >= 4.5 && s.h >= 7;
+                const showLogo = s.w >= 4 && s.h >= 7;
+                const logoSize =
+                  s.w >= 11 && s.h >= 13 ? 40 : s.w >= 7 && s.h >= 9 ? 28 : 18;
                 return (
                   <div
                     key={s.symbol}
@@ -923,6 +945,7 @@ export function StockHeatmap() {
                       background: tileBg(s.change),
                     }}
                   >
+                    {showLogo && <TileLogo symbol={s.symbol} size={logoSize} />}
                     {showSym && (
                       <span className="px-0.5 text-[0.7rem] font-bold leading-tight text-foreground">
                         {s.symbol}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -702,7 +702,97 @@ export function SectorRotation() {
 }
 
 
-// ── Stock Heatmap (sector-ranked square grid) ───────────────────────
+// ── Stock Heatmap (squarified treemap) ──────────────────────────────
+
+interface HeatmapStock {
+  symbol: string;
+  name: string;
+  sector: string;
+  marketCap: number;
+  change: number | null;
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Squarified treemap (Bruls et al.). Lays weighted items into the given rect
+ *  so tile aspect ratios stay close to 1. Coordinates are in the same units as
+ *  the input rect (we use a 0–100 percentage space for responsive rendering). */
+function squarify<T extends { value: number }>(
+  data: T[],
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+): (T & Rect)[] {
+  const out: (T & Rect)[] = [];
+  const items = data.filter((d) => d.value > 0).sort((a, b) => b.value - a.value);
+  const total = items.reduce((s, d) => s + d.value, 0);
+  if (total <= 0 || W <= 0 || H <= 0) return out;
+
+  const scale = (W * H) / total;
+  const vals = items.map((d) => ({ d, area: d.value * scale }));
+
+  let rx = X,
+    ry = Y,
+    rw = W,
+    rh = H;
+  let row: { d: T; area: number }[] = [];
+
+  const worst = (r: typeof row, side: number) => {
+    const sum = r.reduce((s, q) => s + q.area, 0);
+    const mx = Math.max(...r.map((q) => q.area));
+    const mn = Math.min(...r.map((q) => q.area));
+    const s2 = sum * sum;
+    const l2 = side * side;
+    return Math.max((l2 * mx) / s2, s2 / (l2 * mn));
+  };
+
+  const layout = (r: typeof row, vertical: boolean) => {
+    const sum = r.reduce((s, q) => s + q.area, 0);
+    if (vertical) {
+      const colW = sum / rh;
+      let oy = ry;
+      for (const q of r) {
+        const cellH = q.area / colW;
+        out.push({ ...q.d, x: rx, y: oy, w: colW, h: cellH });
+        oy += cellH;
+      }
+      rx += colW;
+      rw -= colW;
+    } else {
+      const rowH = sum / rw;
+      let ox = rx;
+      for (const q of r) {
+        const cellW = q.area / rowH;
+        out.push({ ...q.d, x: ox, y: ry, w: cellW, h: rowH });
+        ox += cellW;
+      }
+      ry += rowH;
+      rh -= rowH;
+    }
+  };
+
+  let i = 0;
+  while (i < vals.length) {
+    const vertical = rw >= rh;
+    const side = vertical ? rh : rw;
+    const next = [...row, vals[i]!];
+    if (row.length === 0 || worst(row, side) >= worst(next, side)) {
+      row = next;
+      i++;
+    } else {
+      layout(row, vertical);
+      row = [];
+    }
+  }
+  if (row.length) layout(row, rw >= rh);
+  return out;
+}
 
 /** Tile background: green for gains, red for losses, intensity scaled by
  *  magnitude (capped at ±4%). Matches the SectorHeatmap color convention. */
@@ -726,22 +816,47 @@ function fmtPct(change: number | null): string {
   return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
 }
 
-/** Market heatmap as a square grid of equal square tiles, one per company,
- *  ordered by market cap (largest first), colored by today's % change.
- *  At xl the grid is 10 columns × 10 rows for the top 100 → a clean square. */
+/** Finviz/TradingView-style market map: largest US companies as a squarified
+ *  treemap, grouped by sector, tiles sized by market cap and colored by today's
+ *  move. Fills the height of its column (the 3 stacked charts on the left). */
 export function StockHeatmap() {
   const { data, isLoading } = api.asset.stockHeatmap.useQuery(
     { limit: 100 },
     REFETCH,
   );
 
-  const stocks = useMemo(() => {
+  // Two-level treemap: partition the canvas among sectors (by total market
+  // cap), then squarify each sector's stocks within its rect.
+  const tiles = useMemo(() => {
     if (!data?.length) return [];
-    return [...data].sort((a, b) => b.marketCap - a.marketCap);
+    const bySector = new Map<string, HeatmapStock[]>();
+    for (const s of data) {
+      const arr = bySector.get(s.sector) ?? [];
+      arr.push(s);
+      bySector.set(s.sector, arr);
+    }
+    const sectors = [...bySector.entries()].map(([sector, stocks]) => ({
+      sector,
+      stocks,
+      value: stocks.reduce((sum, s) => sum + s.marketCap, 0),
+    }));
+
+    const sectorRects = squarify(sectors, 0, 0, 100, 100);
+    return sectorRects.map((sr) => ({
+      sector: sr.sector,
+      rect: { x: sr.x, y: sr.y, w: sr.w, h: sr.h },
+      stocks: squarify(
+        sr.stocks.map((s) => ({ ...s, value: s.marketCap })),
+        sr.x,
+        sr.y,
+        sr.w,
+        sr.h,
+      ),
+    }));
   }, [data]);
 
   return (
-    <div className="flex flex-col rounded-xl border border-border bg-background p-4">
+    <div className="flex h-full flex-col rounded-xl border border-border bg-background p-4">
       <div className="mb-1 flex items-start justify-between gap-3">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           Market Heatmap
@@ -759,37 +874,70 @@ export function StockHeatmap() {
         </div>
       </div>
       <p className="mb-3 text-xs text-muted-foreground">
-        Top 100 US companies by market cap, ordered largest first, colored by
-        today&apos;s move.
+        Top 100 US companies by market cap, grouped by sector. Tile size = market
+        cap, color = today&apos;s move.
       </p>
 
       {isLoading ? (
-        <div className="flex aspect-square items-center justify-center text-sm text-muted-foreground">
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           Loading…
         </div>
-      ) : stocks.length === 0 ? (
-        <div className="flex aspect-square items-center justify-center text-sm text-muted-foreground">
+      ) : tiles.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No data
         </div>
       ) : (
-        <div className="grid grid-cols-6 gap-1 sm:grid-cols-8 xl:grid-cols-10">
-          {stocks.map((s) => (
-            <div
-              key={s.symbol}
-              title={`${s.symbol} · ${s.name} · ${s.sector} · ${fmtCap(
-                s.marketCap,
-              )} · ${fmtPct(s.change)}`}
-              className="flex aspect-square flex-col items-center justify-center overflow-hidden rounded-sm px-0.5 text-center"
-              style={{ background: tileBg(s.change) }}
-            >
-              <span className="w-full truncate text-[0.7rem] font-bold leading-tight text-foreground">
-                {s.symbol}
-              </span>
-              <span className="text-[0.6rem] tabular-nums leading-tight text-foreground/80">
-                {s.change == null
-                  ? "—"
-                  : `${s.change >= 0 ? "+" : ""}${s.change.toFixed(1)}%`}
-              </span>
+        <div className="relative min-h-[480px] w-full flex-1 overflow-hidden rounded-lg">
+          {tiles.map(({ sector, rect, stocks }) => (
+            <div key={sector}>
+              {/* sector outline + label */}
+              <div
+                className="pointer-events-none absolute z-10"
+                style={{
+                  left: `${rect.x}%`,
+                  top: `${rect.y}%`,
+                  width: `${rect.w}%`,
+                  height: `${rect.h}%`,
+                }}
+              >
+                <span className="absolute left-1 top-0.5 rounded-sm bg-background/70 px-1 text-[0.6rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {sector}
+                </span>
+              </div>
+              {/* stock tiles */}
+              {stocks.map((s) => {
+                const showSym = s.w >= 3 && s.h >= 4;
+                const showPct = s.w >= 4.5 && s.h >= 7;
+                return (
+                  <div
+                    key={s.symbol}
+                    title={`${s.symbol} · ${s.name} · ${fmtCap(
+                      s.marketCap,
+                    )} · ${fmtPct(s.change)}`}
+                    className="absolute flex flex-col items-center justify-center overflow-hidden border border-background/60 text-center"
+                    style={{
+                      left: `${s.x}%`,
+                      top: `${s.y}%`,
+                      width: `${s.w}%`,
+                      height: `${s.h}%`,
+                      background: tileBg(s.change),
+                    }}
+                  >
+                    {showSym && (
+                      <span className="px-0.5 text-[0.7rem] font-bold leading-tight text-foreground">
+                        {s.symbol}
+                      </span>
+                    )}
+                    {showPct && (
+                      <span className="text-[0.6rem] tabular-nums leading-tight text-foreground/80">
+                        {s.change == null
+                          ? "—"
+                          : `${s.change >= 0 ? "+" : ""}${s.change.toFixed(1)}%`}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           ))}
         </div>

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -817,9 +817,31 @@ function fmtPct(change: number | null): string {
   return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
 }
 
+/** Black or white logo chip, chosen by the tile's luminance so the circle
+ *  contrasts with the tile (bright tiles get a black chip, dark ones white). */
+function chipBg(change: number | null): string {
+  if (change == null) return "#ffffff";
+  const a = Math.min(1, Math.abs(change) / 4) * 0.8 + 0.08;
+  const base = change >= 0 ? [34, 197, 94] : [239, 68, 68];
+  const card = [17, 17, 19];
+  const r = base[0]! * a + card[0]! * (1 - a);
+  const g = base[1]! * a + card[1]! * (1 - a);
+  const b = base[2]! * a + card[2]! * (1 - a);
+  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return lum > 115 ? "#000000" : "#ffffff";
+}
+
 /** Company logo for a heatmap tile (FMP image endpoint). Hides itself if the
  *  logo 404s — the symbol text below it still identifies the company. */
-function TileLogo({ symbol, size }: { symbol: string; size: number }) {
+function TileLogo({
+  symbol,
+  size,
+  bg,
+}: {
+  symbol: string;
+  size: number;
+  bg: string;
+}) {
   const [failed, setFailed] = useState(false);
   if (failed) return null;
   return (
@@ -829,7 +851,8 @@ function TileLogo({ symbol, size }: { symbol: string; size: number }) {
       width={size}
       height={size}
       unoptimized
-      className="mb-0.5 rounded-sm bg-white/90 object-contain p-px"
+      style={{ background: bg }}
+      className="mb-0.5 rounded-full object-contain p-1"
       onError={() => setFailed(true)}
     />
   );
@@ -919,7 +942,7 @@ export function StockHeatmap() {
                   height: `${rect.h}%`,
                 }}
               >
-                <span className="absolute left-1 top-0.5 rounded-sm bg-background/70 px-1 text-[0.6rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                <span className="absolute left-1 top-0.5 rounded bg-background/80 px-1.5 py-0.5 text-xs font-bold uppercase tracking-wide text-foreground">
                   {sector}
                 </span>
               </div>
@@ -945,7 +968,13 @@ export function StockHeatmap() {
                       background: tileBg(s.change),
                     }}
                   >
-                    {showLogo && <TileLogo symbol={s.symbol} size={logoSize} />}
+                    {showLogo && (
+                      <TileLogo
+                        symbol={s.symbol}
+                        size={logoSize}
+                        bg={chipBg(s.change)}
+                      />
+                    )}
                     {showSym && (
                       <span className="px-0.5 text-[0.7rem] font-bold leading-tight text-foreground">
                         {s.symbol}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -701,7 +701,8 @@ export function SectorRotation() {
   );
 }
 
-// ── Stock Heatmap ───────────────────────────────────────────────────
+
+// ── Stock Heatmap (squarified treemap) ──────────────────────────────
 
 interface HeatmapStock {
   symbol: string;
@@ -711,11 +712,93 @@ interface HeatmapStock {
   change: number | null;
 }
 
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Squarified treemap (Bruls et al.). Lays weighted items into the given rect
+ *  so tile aspect ratios stay close to 1. Coordinates are in the same units as
+ *  the input rect (we use a 0–100 percentage space for responsive rendering). */
+function squarify<T extends { value: number }>(
+  data: T[],
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+): (T & Rect)[] {
+  const out: (T & Rect)[] = [];
+  const items = data.filter((d) => d.value > 0).sort((a, b) => b.value - a.value);
+  const total = items.reduce((s, d) => s + d.value, 0);
+  if (total <= 0 || W <= 0 || H <= 0) return out;
+
+  const scale = (W * H) / total;
+  const vals = items.map((d) => ({ d, area: d.value * scale }));
+
+  let rx = X,
+    ry = Y,
+    rw = W,
+    rh = H;
+  let row: { d: T; area: number }[] = [];
+
+  const worst = (r: typeof row, side: number) => {
+    const sum = r.reduce((s, q) => s + q.area, 0);
+    const mx = Math.max(...r.map((q) => q.area));
+    const mn = Math.min(...r.map((q) => q.area));
+    const s2 = sum * sum;
+    const l2 = side * side;
+    return Math.max((l2 * mx) / s2, s2 / (l2 * mn));
+  };
+
+  const layout = (r: typeof row, vertical: boolean) => {
+    const sum = r.reduce((s, q) => s + q.area, 0);
+    if (vertical) {
+      const colW = sum / rh;
+      let oy = ry;
+      for (const q of r) {
+        const cellH = q.area / colW;
+        out.push({ ...q.d, x: rx, y: oy, w: colW, h: cellH });
+        oy += cellH;
+      }
+      rx += colW;
+      rw -= colW;
+    } else {
+      const rowH = sum / rw;
+      let ox = rx;
+      for (const q of r) {
+        const cellW = q.area / rowH;
+        out.push({ ...q.d, x: ox, y: ry, w: cellW, h: rowH });
+        ox += cellW;
+      }
+      ry += rowH;
+      rh -= rowH;
+    }
+  };
+
+  let i = 0;
+  while (i < vals.length) {
+    const vertical = rw >= rh;
+    const side = vertical ? rh : rw;
+    const next = [...row, vals[i]!];
+    if (row.length === 0 || worst(row, side) >= worst(next, side)) {
+      row = next;
+      i++;
+    } else {
+      layout(row, vertical);
+      row = [];
+    }
+  }
+  if (row.length) layout(row, rw >= rh);
+  return out;
+}
+
 /** Tile background: green for gains, red for losses, intensity scaled by
  *  magnitude (capped at ±4%). Matches the SectorHeatmap color convention. */
 function tileBg(change: number | null): string {
-  if (change == null) return "color-mix(in srgb, #64748b 18%, transparent)";
-  const a = Math.round(Math.min(1, Math.abs(change) / 4) * 78) + 8;
+  if (change == null) return "color-mix(in srgb, #64748b 20%, transparent)";
+  const a = Math.round(Math.min(1, Math.abs(change) / 4) * 80) + 8;
   return change >= 0
     ? `color-mix(in srgb, #22c55e ${a}%, transparent)`
     : `color-mix(in srgb, #ef4444 ${a}%, transparent)`;
@@ -728,15 +811,22 @@ function fmtCap(n: number): string {
   return `$${n}`;
 }
 
-/** Finviz-style market map: largest US companies grouped by sector, each tile
- *  sized (flex-grow) by market cap and colored by today's % change. */
+function fmtPct(change: number | null): string {
+  if (change == null) return "—";
+  return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
+}
+
+/** Finviz-style market map: largest US companies as a squarified treemap,
+ *  grouped by sector, tiles sized by market cap and colored by today's move. */
 export function StockHeatmap() {
   const { data, isLoading } = api.asset.stockHeatmap.useQuery(
     { limit: 100 },
     REFETCH,
   );
 
-  const sectors = useMemo(() => {
+  // Two-level treemap: partition the canvas among sectors (by total market
+  // cap), then squarify each sector's stocks within its rect.
+  const tiles = useMemo(() => {
     if (!data?.length) return [];
     const bySector = new Map<string, HeatmapStock[]>();
     for (const s of data) {
@@ -744,13 +834,24 @@ export function StockHeatmap() {
       arr.push(s);
       bySector.set(s.sector, arr);
     }
-    return [...bySector.entries()]
-      .map(([sector, stocks]) => ({
-        sector,
-        stocks: [...stocks].sort((a, b) => b.marketCap - a.marketCap),
-        total: stocks.reduce((sum, s) => sum + s.marketCap, 0),
-      }))
-      .sort((a, b) => b.total - a.total);
+    const sectors = [...bySector.entries()].map(([sector, stocks]) => ({
+      sector,
+      stocks,
+      value: stocks.reduce((sum, s) => sum + s.marketCap, 0),
+    }));
+
+    const sectorRects = squarify(sectors, 0, 0, 100, 100);
+    return sectorRects.map((sr) => ({
+      sector: sr.sector,
+      rect: { x: sr.x, y: sr.y, w: sr.w, h: sr.h },
+      stocks: squarify(
+        sr.stocks.map((s) => ({ ...s, value: s.marketCap })),
+        sr.x,
+        sr.y,
+        sr.w,
+        sr.h,
+      ),
+    }));
   }, [data]);
 
   return (
@@ -765,7 +866,7 @@ export function StockHeatmap() {
             className="inline-block h-2 w-16 rounded-sm"
             style={{
               background:
-                "linear-gradient(to right, #ef4444, color-mix(in srgb, #64748b 18%, transparent), #22c55e)",
+                "linear-gradient(to right, #ef4444, color-mix(in srgb, #64748b 20%, transparent), #22c55e)",
             }}
           />
           <span>+4%</span>
@@ -777,51 +878,65 @@ export function StockHeatmap() {
       </p>
 
       {isLoading ? (
-        <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+        <div className="flex h-[480px] items-center justify-center text-sm text-muted-foreground">
           Loading…
         </div>
-      ) : sectors.length === 0 ? (
-        <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+      ) : tiles.length === 0 ? (
+        <div className="flex h-[480px] items-center justify-center text-sm text-muted-foreground">
           No data
         </div>
       ) : (
-        <div className="flex flex-wrap gap-2" style={{ minHeight: 360 }}>
-          {sectors.map(({ sector, stocks, total }) => (
-            <div
-              key={sector}
-              className="flex min-w-[180px] flex-col"
-              style={{ flexGrow: total, flexBasis: 0 }}
-            >
-              <div className="mb-1 truncate text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                {sector}
+        <div className="relative h-[480px] w-full overflow-hidden rounded-lg">
+          {tiles.map(({ sector, rect, stocks }) => (
+            <div key={sector}>
+              {/* sector outline + label */}
+              <div
+                className="pointer-events-none absolute z-10"
+                style={{
+                  left: `${rect.x}%`,
+                  top: `${rect.y}%`,
+                  width: `${rect.w}%`,
+                  height: `${rect.h}%`,
+                }}
+              >
+                <span className="absolute left-1 top-0.5 rounded-sm bg-background/70 px-1 text-[0.6rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {sector}
+                </span>
               </div>
-              <div className="flex flex-1 flex-wrap content-start gap-1">
-                {stocks.map((s) => (
+              {/* stock tiles */}
+              {stocks.map((s) => {
+                const showSym = s.w >= 3 && s.h >= 4;
+                const showPct = s.w >= 4.5 && s.h >= 7;
+                return (
                   <div
                     key={s.symbol}
-                    title={`${s.name} · ${fmtCap(s.marketCap)} · ${
-                      s.change == null
-                        ? "—"
-                        : (s.change >= 0 ? "+" : "") + s.change.toFixed(2) + "%"
-                    }`}
-                    className="flex min-w-[56px] flex-col items-center justify-center rounded px-1 py-1.5 text-center"
+                    title={`${s.symbol} · ${s.name} · ${fmtCap(
+                      s.marketCap,
+                    )} · ${fmtPct(s.change)}`}
+                    className="absolute flex flex-col items-center justify-center overflow-hidden border border-background/60 text-center"
                     style={{
-                      flexGrow: s.marketCap,
-                      flexBasis: 0,
+                      left: `${s.x}%`,
+                      top: `${s.y}%`,
+                      width: `${s.w}%`,
+                      height: `${s.h}%`,
                       background: tileBg(s.change),
                     }}
                   >
-                    <span className="text-xs font-bold text-foreground">
-                      {s.symbol}
-                    </span>
-                    <span className="text-[0.6rem] tabular-nums text-foreground/80">
-                      {s.change == null
-                        ? "—"
-                        : (s.change >= 0 ? "+" : "") + s.change.toFixed(1) + "%"}
-                    </span>
+                    {showSym && (
+                      <span className="px-0.5 text-[0.7rem] font-bold leading-tight text-foreground">
+                        {s.symbol}
+                      </span>
+                    )}
+                    {showPct && (
+                      <span className="text-[0.6rem] tabular-nums leading-tight text-foreground/80">
+                        {s.change == null
+                          ? "—"
+                          : `${s.change >= 0 ? "+" : ""}${s.change.toFixed(1)}%`}
+                      </span>
+                    )}
                   </div>
-                ))}
-              </div>
+                );
+              })}
             </div>
           ))}
         </div>

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import {
   CartesianGrid,
+  Customized,
   LabelList,
   Line,
   LineChart,
@@ -569,6 +570,41 @@ function SectorRRG({ rows }: { rows: Row[] }) {
     return { series: norm, dom: maxAbs * 1.12 };
   }, [rows]);
 
+  // Arrowhead at each trail's head, oriented along its last segment. Drawn in a
+  // Customized layer so we can use the chart's pixel scales for direction.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderArrows = (cprops: any) => {
+    const xMap = cprops.xAxisMap ?? {};
+    const yMap = cprops.yAxisMap ?? {};
+    const xScale = xMap[Object.keys(xMap)[0] ?? ""]?.scale;
+    const yScale = yMap[Object.keys(yMap)[0] ?? ""]?.scale;
+    if (!xScale || !yScale) return null;
+    return (
+      <g>
+        {series.map((s) => {
+          const n = s.pts.length;
+          if (n < 2) return null;
+          const a = s.pts[n - 2]!;
+          const b = s.pts[n - 1]!;
+          const x2 = xScale(b.x);
+          const y2 = yScale(b.y);
+          const ang = Math.atan2(y2 - yScale(a.y), x2 - xScale(a.x));
+          const L = 9;
+          const w = 0.42;
+          const p2 = `${x2 - L * Math.cos(ang - w)},${y2 - L * Math.sin(ang - w)}`;
+          const p3 = `${x2 - L * Math.cos(ang + w)},${y2 - L * Math.sin(ang + w)}`;
+          return (
+            <polygon
+              key={s.symbol}
+              points={`${x2},${y2} ${p2} ${p3}`}
+              fill={s.color}
+            />
+          );
+        })}
+      </g>
+    );
+  };
+
   if (!series.length) return null;
   return (
     <>
@@ -588,41 +624,11 @@ function SectorRRG({ rows }: { rows: Row[] }) {
                 key={s.symbol}
                 data={s.pts}
                 fill={s.color}
-                line={{ stroke: s.color, strokeWidth: 1.5, strokeOpacity: 0.45 }}
+                line={{ stroke: s.color, strokeWidth: 1.5, strokeOpacity: 0.55 }}
                 isAnimationActive={false}
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                shape={(props: any) => {
-                  // recharts doesn't pass `index` to Scatter shapes, so we read
-                  // the start/end/progress metadata off the data point itself.
-                  const pt = props.payload ?? {};
-                  const isLast = !!pt.last;
-                  const isFirst = !!pt.first;
-                  const prog = typeof pt.prog === "number" ? pt.prog : 1;
-                  // Hollow ring marks the start (oldest); the trail grows in
-                  // size + opacity toward the solid "now" dot at the end.
-                  if (isFirst && !isLast) {
-                    return (
-                      <circle
-                        cx={props.cx}
-                        cy={props.cy}
-                        r={4}
-                        fill="none"
-                        stroke={s.color}
-                        strokeWidth={2}
-                        strokeOpacity={0.9}
-                      />
-                    );
-                  }
-                  return (
-                    <circle
-                      cx={props.cx}
-                      cy={props.cy}
-                      r={isLast ? 6 : 2 + prog * 2.5}
-                      fill={s.color}
-                      fillOpacity={isLast ? 1 : 0.35 + prog * 0.55}
-                    />
-                  );
-                }}
+                // No per-point dots — just the tail line. The current position
+                // and direction are shown by an arrowhead (drawn in <Customized>).
+                shape={() => <g />}
               >
                 <LabelList
                   dataKey="x"
@@ -637,15 +643,14 @@ function SectorRRG({ rows }: { rows: Row[] }) {
                 />
               </Scatter>
             ))}
+            <Customized component={renderArrows} />
           </ScatterChart>
         </ResponsiveContainer>
       </div>
-      <div className="mt-1 flex items-center justify-center gap-1.5 text-[0.62rem] text-muted-foreground">
-        <span className="inline-block h-2 w-2 rounded-full border border-muted-foreground" />
-        <span>start</span>
-        <span className="opacity-60">→ trail →</span>
-        <span className="inline-block h-2.5 w-2.5 rounded-full bg-muted-foreground" />
-        <span>now</span>
+      <div className="mt-1 flex items-center justify-center gap-1 text-[0.62rem] text-muted-foreground">
+        <span>tail = past&nbsp;</span>
+        <span className="opacity-60">→</span>
+        <span>&nbsp;▶ arrowhead = now</span>
       </div>
       <div className="mt-1 grid grid-cols-2 text-[0.62rem] text-muted-foreground">
         <span className="text-[#3b82f6]">↖ Improving</span>

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -399,7 +399,7 @@ function SectorBump({ rows }: { rows: Row[] }) {
                   dataKey={s.symbol}
                   name={s.symbol}
                   stroke={color}
-                  strokeWidth={isHot ? 3.25 : 1.5}
+                  strokeWidth={isHot ? 4 : 2.5}
                   strokeOpacity={dimmed ? 0.2 : 1}
                   dot={dimmed ? false : { r: 2 }}
                   activeDot={{ r: 4 }}

--- a/src/components/features/macro-charts.tsx
+++ b/src/components/features/macro-charts.tsx
@@ -817,42 +817,20 @@ function fmtPct(change: number | null): string {
   return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
 }
 
-/** Black or white logo chip, chosen by the tile's luminance so the circle
- *  contrasts with the tile (bright tiles get a black chip, dark ones white). */
-function chipBg(change: number | null): string {
-  if (change == null) return "#ffffff";
-  const a = Math.min(1, Math.abs(change) / 4) * 0.8 + 0.08;
-  const base = change >= 0 ? [34, 197, 94] : [239, 68, 68];
-  const card = [17, 17, 19];
-  const r = base[0]! * a + card[0]! * (1 - a);
-  const g = base[1]! * a + card[1]! * (1 - a);
-  const b = base[2]! * a + card[2]! * (1 - a);
-  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-  return lum > 115 ? "#000000" : "#ffffff";
-}
-
-/** Company logo for a heatmap tile (FMP image endpoint). Hides itself if the
- *  logo 404s — the symbol text below it still identifies the company. */
-function TileLogo({
-  symbol,
-  size,
-  bg,
-}: {
-  symbol: string;
-  size: number;
-  bg: string;
-}) {
+/** Company logo for a heatmap tile. Uses Parqet's free by-ticker logo service
+ *  (crisp brand badges with their own backgrounds). Hides itself if the logo
+ *  is missing — the symbol text below still identifies the company. */
+function TileLogo({ symbol, size }: { symbol: string; size: number }) {
   const [failed, setFailed] = useState(false);
   if (failed) return null;
   return (
     <Image
-      src={`https://financialmodelingprep.com/image-stock/${symbol}.png`}
+      src={`https://assets.parqet.com/logos/symbol/${symbol}?format=png&size=128`}
       alt={symbol}
       width={size}
       height={size}
       unoptimized
-      style={{ background: bg }}
-      className="mb-0.5 rounded-full object-contain p-1"
+      className="mb-0.5 rounded-md object-contain ring-1 ring-black/20"
       onError={() => setFailed(true)}
     />
   );
@@ -969,11 +947,7 @@ export function StockHeatmap() {
                     }}
                   >
                     {showLogo && (
-                      <TileLogo
-                        symbol={s.symbol}
-                        size={logoSize}
-                        bg={chipBg(s.change)}
-                      />
+                      <TileLogo symbol={s.symbol} size={logoSize} />
                     )}
                     {showSym && (
                       <span className="px-0.5 text-[0.7rem] font-bold leading-tight text-foreground">

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -1382,15 +1382,19 @@ export function MacroDashboard() {
         <DollarIndexCard />
         <TreasuryCard />
 
-        {/* Full-width market heatmap — market-at-a-glance */}
-        <div className="md:col-span-2 xl:col-span-3">
-          <StockHeatmap />
+        {/* Markets row: 1/3 stacked line charts | 2/3 square market heatmap */}
+        <div className="grid items-start gap-4 md:col-span-2 xl:col-span-3 xl:grid-cols-3">
+          <div className="flex flex-col gap-4">
+            <MacroLineCard title="Global Market Indices" syms={INDICES} kind="indices" />
+            <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />
+            <MacroLineCard title="Commodities" syms={COMMODITIES_GROUP} kind="commodities" />
+          </div>
+          <div className="xl:col-span-2">
+            <StockHeatmap />
+          </div>
         </div>
 
-        {/* Row: Markets — overlaid 1Y line charts */}
-        <MacroLineCard title="Global Market Indices" syms={INDICES} kind="indices" />
-        <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />
-        <MacroLineCard title="Commodities" syms={COMMODITIES_GROUP} kind="commodities" />
+        {/* Crypto + sector rotation */}
         <MacroLineCard title="Crypto" syms={CRYPTO} kind="crypto" />
 
         {/* Sector rotation over time (same width as Market News below) */}

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -1383,7 +1383,7 @@ export function MacroDashboard() {
         <TreasuryCard />
 
         {/* Markets row: 1/3 stacked line charts | 2/3 square market heatmap */}
-        <div className="grid items-start gap-4 md:col-span-2 xl:col-span-3 xl:grid-cols-3">
+        <div className="grid gap-4 md:col-span-2 xl:col-span-3 xl:grid-cols-3">
           <div className="flex flex-col gap-4">
             <MacroLineCard title="Global Market Indices" syms={INDICES} kind="indices" />
             <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -1382,16 +1382,16 @@ export function MacroDashboard() {
         <DollarIndexCard />
         <TreasuryCard />
 
-        {/* Row 2: Markets — overlaid 1Y line charts */}
+        {/* Full-width market heatmap — market-at-a-glance */}
+        <div className="md:col-span-2 xl:col-span-3">
+          <StockHeatmap />
+        </div>
+
+        {/* Row: Markets — overlaid 1Y line charts */}
         <MacroLineCard title="Global Market Indices" syms={INDICES} kind="indices" />
         <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />
         <MacroLineCard title="Commodities" syms={COMMODITIES_GROUP} kind="commodities" />
         <MacroLineCard title="Crypto" syms={CRYPTO} kind="crypto" />
-
-        {/* Full-width market heatmap */}
-        <div className="md:col-span-2 xl:col-span-3">
-          <StockHeatmap />
-        </div>
 
         {/* Sector rotation over time (same width as Market News below) */}
         <div className="md:col-span-2 xl:col-span-2">

--- a/src/components/features/macro-dashboard.tsx
+++ b/src/components/features/macro-dashboard.tsx
@@ -29,6 +29,7 @@ import { MacroFedDataBlock } from "./macro-fed-data";
 import {
   MacroLineCard,
   SectorRotation,
+  StockHeatmap,
   INDICES,
   FOREX,
   COMMODITIES as COMMODITIES_GROUP,
@@ -1386,6 +1387,11 @@ export function MacroDashboard() {
         <MacroLineCard title="Key Forex Rates" syms={FOREX} kind="forex" />
         <MacroLineCard title="Commodities" syms={COMMODITIES_GROUP} kind="commodities" />
         <MacroLineCard title="Crypto" syms={CRYPTO} kind="crypto" />
+
+        {/* Full-width market heatmap */}
+        <div className="md:col-span-2 xl:col-span-3">
+          <StockHeatmap />
+        </div>
 
         {/* Sector rotation over time (same width as Market News below) */}
         <div className="md:col-span-2 xl:col-span-2">

--- a/src/server/api/routers/assets.ts
+++ b/src/server/api/routers/assets.ts
@@ -1363,23 +1363,38 @@ export const assetsRouter = createTRPCRouter({
       const limit = input?.limit ?? 100;
 
       // 1. Screener → market cap + sector for the largest actively-traded US names.
-      const screen = await fmp.get<FMPStockScreenerResponse>(
-        `/api/v3/stock-screener`,
-        {
-          params: {
-            marketCapMoreThan: 10_000_000_000,
-            isEtf: false,
-            isFund: false,
-            isActivelyTrading: true,
-            country: "US",
-            limit: 500,
-            apikey: apiKey,
-          },
-        },
+      //    Query NASDAQ + NYSE separately (the screener's `exchange` param takes
+      //    a single value) and merge.
+      const PRIMARY_EXCHANGES = ["nasdaq", "nyse"] as const;
+      const screens = await Promise.all(
+        PRIMARY_EXCHANGES.map((exchange) =>
+          fmp.get<FMPStockScreenerResponse>(`/api/v3/stock-screener`, {
+            params: {
+              marketCapMoreThan: 10_000_000_000,
+              isEtf: false,
+              isFund: false,
+              isActivelyTrading: true,
+              country: "US",
+              exchange,
+              limit: 500,
+              apikey: apiKey,
+            },
+          }),
+        ),
       );
 
-      const top = (screen.data ?? [])
-        .filter((r) => r.marketCap > 0 && r.sector)
+      // Dedupe by symbol and drop foreign cross-listings (e.g. AAPL.MX, AMD.BA),
+      // which carry a "." suffix. US primary tickers don't (BRK-B uses a hyphen).
+      const seen = new Set<string>();
+      const top = screens
+        .flatMap((s) => s.data ?? [])
+        .filter((r) => {
+          if (!(r.marketCap > 0) || !r.sector) return false;
+          if (r.symbol.includes(".")) return false;
+          if (seen.has(r.symbol)) return false;
+          seen.add(r.symbol);
+          return true;
+        })
         .sort((a, b) => b.marketCap - a.marketCap)
         .slice(0, limit);
 

--- a/src/server/api/routers/assets.ts
+++ b/src/server/api/routers/assets.ts
@@ -1354,6 +1354,59 @@ export const assetsRouter = createTRPCRouter({
     });
   }),
 
+  // Stock heatmap data: the largest US companies as a sector-grouped,
+  // market-cap-weighted, %-change-colored tile map (Finviz-style). Merges the
+  // screener (for market cap + sector) with batch quotes (for today's change).
+  stockHeatmap: publicProcedure
+    .input(z.object({ limit: z.number().min(10).max(200).default(100) }).optional())
+    .query(async ({ input }) => {
+      const limit = input?.limit ?? 100;
+
+      // 1. Screener → market cap + sector for the largest actively-traded US names.
+      const screen = await fmp.get<FMPStockScreenerResponse>(
+        `/api/v3/stock-screener`,
+        {
+          params: {
+            marketCapMoreThan: 10_000_000_000,
+            isEtf: false,
+            isFund: false,
+            isActivelyTrading: true,
+            country: "US",
+            limit: 500,
+            apikey: apiKey,
+          },
+        },
+      );
+
+      const top = (screen.data ?? [])
+        .filter((r) => r.marketCap > 0 && r.sector)
+        .sort((a, b) => b.marketCap - a.marketCap)
+        .slice(0, limit);
+
+      if (top.length === 0) return [];
+
+      // 2. Batch quote those symbols → today's % change.
+      const symbols = top.map((r) => r.symbol).join(",");
+      const quotes = await fmp.get<
+        { symbol: string; changesPercentage: number }[]
+      >(`/api/v3/quote/${symbols}`, {
+        params: { apikey: apiKey },
+      });
+
+      const changeBySymbol = new Map(
+        (quotes.data ?? []).map((q) => [q.symbol, q.changesPercentage]),
+      );
+
+      // 3. Merge.
+      return top.map((r) => ({
+        symbol: r.symbol,
+        name: r.companyName,
+        sector: r.sector,
+        marketCap: r.marketCap,
+        change: changeBySymbol.get(r.symbol) ?? null,
+      }));
+    }),
+
   treasuryRates: publicProcedure.query(async () => {
     const res = await fmp.get<
       {


### PR DESCRIPTION
## Summary
Adds a **stock heatmap** to the macro page — the largest US companies as a Finviz/TradingView-style **squarified treemap**, grouped by sector, tiles sized by market cap and colored by today's % change.

### What's new
1. **`asset.stockHeatmap` tRPC procedure** (`assets.ts`)
   - Queries the FMP screener on **NASDAQ + NYSE** (US, market cap > $10B, actively trading, non-ETF/fund), **dedupes by ticker and drops foreign cross-listings** (dotted symbols like `AAPL.MX`, `AMD.BA`), takes the **top N by market cap** (default 100).
   - Batch-quotes them (`/api/v3/quote/{symbols}`) for today's `changesPercentage`.
   - Returns merged `{ symbol, name, sector, marketCap, change }[]`.
2. **`StockHeatmap` component** (`macro-charts.tsx`)
   - **Squarified treemap** (Bruls et al.), two-level: partition the canvas among sectors by total market cap, then squarify each sector's stocks within its rect. Tiles keep near-1 aspect ratios (no squished columns).
   - Rendered in a responsive 0–100% coordinate space (absolute-positioned tiles), colored via `color-mix` green/red intensity (±4% cap), matching the existing `SectorHeatmap`. Sector labels overlaid; hover tooltip = symbol · name · cap · change. Labels hidden on tiles too small to fit.
3. **Placement** (`macro-dashboard.tsx`): full-width row (`xl:col-span-3`) below the market line charts.

### Why a squarified treemap
It's the standard for market-cap-weighted "market at a glance" views (Finviz, TradingView): tiles stay proportional with readable aspect ratios, unlike a flex/column layout which squishes small sectors. No new dependency — the geometry is hand-rolled and **unit-tested in Node** (exact tiling, no overlap/out-of-bounds across random inputs).

### History
- v1 used a flex layout + an over-broad screener that pulled foreign cross-listings (visible as `AAPL.MX`/`AMD.BA` duplicates). Both fixed here.
- Rebased onto `main` after #53 merged (conflict resolved).

### Verification caveat
This workspace copy has no `node_modules` (+ private `@mtosity/design-system`), so I verified types by inspection and the treemap math via standalone Node tests — **relying on CI + the Vercel preview** for the full render.

### Follow-ups (not included)
- Mobile: reduce tile count / switch to a sector summary on small screens.
- Tap-to-drill into a ticker; selectable universe (S&P 100 / most-active).