### PR TITLE
fix(influencers): stack action tag above its description

### DIFF
--- a/src/components/features/influencer-digest.tsx
+++ b/src/components/features/influencer-digest.tsx
@@ -110,10 +110,10 @@ export function InfluencerDigest({ digest }: { digest: Digest }) {
             {actions.map((a, i) => (
               <div
                 key={i}
-                className="flex items-start gap-2 rounded-md bg-muted px-3 py-2 text-sm"
+                className="flex flex-col gap-1.5 rounded-md bg-muted px-3 py-2 text-sm"
               >
                 {a.action && (
-                  <Pill className="mt-0.5 shrink-0 bg-primary/15 text-foreground ring-primary/30">
+                  <Pill className="self-start bg-primary/15 text-foreground ring-primary/30">
                     {a.action}
                   </Pill>
                 )}


### PR DESCRIPTION
## Problem
On `/influencers`, each "Recommended actions" item laid the action tag and the ticker rationale **side by side** (`flex items-start gap-2`, tag `shrink-0`). Long tags like **"RAISE CASH AND DIVERSIFY AWAY FROM TOP-10 S&P CONCENTRATION"** took the full row width and squeezed the description into a thin column.

## Fix
Stack them vertically — `flex flex-col gap-1.5`, with the pill `self-start` (its own line, content-width) above the **full-width** description. One-block change in `influencer-digest.tsx`; no logic touched.